### PR TITLE
chore(be): remove unused imports from trivia routes

### DIFF
--- a/BE/src/modules/trivia/trivia.routes.ts
+++ b/BE/src/modules/trivia/trivia.routes.ts
@@ -1,7 +1,5 @@
 import { Application, Router } from 'express';
 import { TriviaController } from './trivia.controller.js';
-import { cacheMiddleware } from '../../middleware/cache.js';
-import { authenticateCombined } from '../../middleware/combinedAuth.js';
 
 /**
  * Register trivia routes with the Express application
@@ -20,4 +18,4 @@ export function registerTriviaRoutes(app: Application): void {
 
     // Register router with prefix
     app.use('/api/trivia', router);
-} 
+}


### PR DESCRIPTION
## Summary
- Drop unused `cacheMiddleware` and `authenticateCombined` imports from `trivia.routes.ts`.
- No runtime behavior change; trivia endpoints stay public as before.

## Why
Dead imports add noise and imply auth/caching that is not actually applied.

## Test plan
- [ ] Confirm `/api/trivia/*` routes still register (server starts)
- [ ] Spot-check trivia player/team/season GET and guess POST still work

Made with [Cursor](https://cursor.com)