### PR TITLE
feat(be): add /health endpoint with DB ping

### DIFF
--- a/BE/src/server.ts
+++ b/BE/src/server.ts
@@ -60,9 +60,18 @@ async function startServer(): Promise<void> {
 
     const server = createServer(app);
 
-    // Handle server graceful shutdown
+    // Handle server graceful shutdown + liveness/readiness probes
     createTerminus(server, {
       signal: 'SIGTERM',
+      healthChecks: {
+        '/health': async () => {
+          if (!AppDataSource.isInitialized) {
+            throw new Error('Database not initialized');
+          }
+          await AppDataSource.query('SELECT 1');
+          return { status: 'ok' };
+        },
+      },
       onSignal: async () => {
         // Cleanup logic before shutdown
         console.log('Server is shutting down');


### PR DESCRIPTION
## Summary
- Wire `@godaddy/terminus` `healthChecks` for `GET /health`.
- Health check verifies the TypeORM data source is initialized and runs `SELECT 1`.

## Why
Deployments currently only get graceful SIGTERM handling. A dedicated health endpoint lets Coolify/Docker mark the service unhealthy when the DB is down.

## Test plan
- [ ] Start the backend with a working DB and `curl http://localhost:3000/health` returns 200
- [ ] Stop Postgres and confirm `/health` fails (non-200)
- [ ] Confirm existing API routes are unaffected

Made with [Cursor](https://cursor.com)