### PR TITLE
refactor(be): share getAllowedOrigins between CORS and CSRF

### DIFF
--- a/BE/src/middleware/csrfProtection.ts
+++ b/BE/src/middleware/csrfProtection.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { CSRF_COOKIE_NAME, AUTH_COOKIE_NAME } from "./authCookie.js";
 import { UnauthorizedError } from "../errors/UnauthorizedError.js";
+import { getAllowedOrigins } from "../utils/allowedOrigins.js";
 
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 const CSRF_EXEMPT_PATHS = new Set([
@@ -9,27 +10,6 @@ const CSRF_EXEMPT_PATHS = new Set([
     "/api/users/logout",
 ]);
 
-function getAllowedOrigins(): string[] {
-    if (process.env.CORS_ORIGINS) {
-        return process.env.CORS_ORIGINS.split(",").map((origin) => origin.trim()).filter(Boolean);
-    }
-
-    if (process.env.NODE_ENV === "production") {
-        return ["https://volleyball4-2.com"];
-    }
-
-    return [
-        "https://volleyball4-2.com",
-        "http://localhost:3000",
-        "http://localhost:5173",
-        "http://localhost:5174",
-        "http://localhost:8080",
-        "http://127.0.0.1:3000",
-        "http://127.0.0.1:5173",
-        "http://127.0.0.1:5174",
-        "http://127.0.0.1:8080",
-    ];
-}
 
 export function csrfProtection(req: Request, res: Response, next: NextFunction): void {
     if (SAFE_METHODS.has(req.method) || CSRF_EXEMPT_PATHS.has(req.path)) {

--- a/BE/src/middleware/globalMiddleware.ts
+++ b/BE/src/middleware/globalMiddleware.ts
@@ -9,30 +9,8 @@ import { authorizeRoles } from "./authorizeRoles.js";
 import { adminRateLimiter } from "./rateLimit.js";
 import { csrfProtection } from "./csrfProtection.js";
 import { adminIpAllowlist } from "./adminIpAllowlist.js";
+import { getAllowedOrigins } from "../utils/allowedOrigins.js";
 
-const PRODUCTION_ORIGINS = ['https://volleyball4-2.com'];
-const DEVELOPMENT_ORIGINS = [
-    'http://localhost:3000',
-    'http://localhost:5173',
-    'http://localhost:5174',
-    'http://localhost:8080',
-    'http://127.0.0.1:3000',
-    'http://127.0.0.1:5173',
-    'http://127.0.0.1:5174',
-    'http://127.0.0.1:8080',
-];
-
-function getAllowedOrigins(): string[] {
-    if (process.env.CORS_ORIGINS) {
-        return process.env.CORS_ORIGINS.split(',').map((origin) => origin.trim()).filter(Boolean);
-    }
-
-    if (process.env.NODE_ENV === 'production') {
-        return PRODUCTION_ORIGINS;
-    }
-
-    return [...PRODUCTION_ORIGINS, ...DEVELOPMENT_ORIGINS];
-}
 
 /**
  * Register all global middleware to the Express application

--- a/BE/src/utils/allowedOrigins.ts
+++ b/BE/src/utils/allowedOrigins.ts
@@ -1,0 +1,27 @@
+const PRODUCTION_ORIGINS = ['https://volleyball4-2.com'];
+const DEVELOPMENT_ORIGINS = [
+    'http://localhost:3000',
+    'http://localhost:5173',
+    'http://localhost:5174',
+    'http://localhost:8080',
+    'http://127.0.0.1:3000',
+    'http://127.0.0.1:5173',
+    'http://127.0.0.1:5174',
+    'http://127.0.0.1:8080',
+];
+
+/**
+ * Origins allowed for CORS and CSRF checks.
+ * Prefer CORS_ORIGINS (comma-separated) when set; otherwise use env defaults.
+ */
+export function getAllowedOrigins(): string[] {
+    if (process.env.CORS_ORIGINS) {
+        return process.env.CORS_ORIGINS.split(',').map((origin) => origin.trim()).filter(Boolean);
+    }
+
+    if (process.env.NODE_ENV === 'production') {
+        return PRODUCTION_ORIGINS;
+    }
+
+    return [...PRODUCTION_ORIGINS, ...DEVELOPMENT_ORIGINS];
+}


### PR DESCRIPTION
## Summary
- Add `BE/src/utils/allowedOrigins.ts` with a single `getAllowedOrigins()` helper.
- Update CORS (`globalMiddleware`) and CSRF middleware to use it.

## Why
Identical origin lists lived in two files and could diverge (they already differed slightly in formatting). One source of truth keeps browser CORS and CSRF origin checks aligned.

## Test plan
- [ ] Login/register from the FE still works (credentials + CSRF)
- [ ] Cross-origin request from an unlisted origin is rejected
- [ ] `CORS_ORIGINS` env override still applies to both CORS and CSRF

Made with [Cursor](https://cursor.com)