### PR TITLE
fix(be): make npm run build work on Windows

### DIFF
--- a/BE/package.json
+++ b/BE/package.json
@@ -11,7 +11,7 @@
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
     "dev": "NODE_OPTIONS=\"--loader ts-node/esm --experimental-specifier-resolution=node\" nodemon src/index.ts",
-    "build": "rm -rf dist && tsc",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "start:prod": "./start.sh",
     "start": "NODE_OPTIONS=\"--loader ts-node/esm --experimental-specifier-resolution=node\" ts-node src/index.ts",
     "seed:reset-user-roles": "node --experimental-specifier-resolution=node reset-user-roles.js"


### PR DESCRIPTION
## Summary
- Replace `rm -rf dist` in the BE `build` script with a cross-platform `fs.rmSync` via Node.

## Why
`rm -rf` fails in Windows PowerShell/cmd, blocking local production builds for Windows contributors.

## Test plan
- [ ] On Windows: `cd BE && npm run build` completes without shell errors
- [ ] On macOS/Linux: `npm run build` still clears `dist` and compiles

Made with [Cursor](https://cursor.com)