### PR TITLE
docs(be): document missing env vars in .env.example

### DIFF
--- a/BE/.env.example
+++ b/BE/.env.example
@@ -24,3 +24,9 @@ REDIS_DISABLED=true
 ALLOW_REGISTRATION=true
 CORS_ORIGINS=http://localhost:5173,http://localhost:8080
 VITE_BACKEND_URL=http://localhost:3000
+
+# Optional — comma-separated IPs allowed to hit /api/admin (empty = allow all)
+# ADMIN_IP_ALLOWLIST=127.0.0.1,::1
+
+# Optional — required for Challonge tournament import in the admin portal
+# CHALLONGE_API_KEY=your-challonge-api-key


### PR DESCRIPTION
## Summary
- Document `ADMIN_IP_ALLOWLIST` and `CHALLONGE_API_KEY` in `BE/.env.example`.

## Why
Both variables are already consumed in code but were easy to miss when setting up environments.

## Test plan
- [ ] Docs-only; app still starts with existing `.env`

Made with [Cursor](https://cursor.com)