### PR TITLE
feat(be): add Zod validation for login body

### DIFF
--- a/BE/src/modules/user/user.routes.ts
+++ b/BE/src/modules/user/user.routes.ts
@@ -1,7 +1,7 @@
 import { Application, Router } from 'express';
 import { UserController } from './user.controller.js';
 import { validate } from '../../middleware/validate.js';
-import { createUserSchema, changeUserRoleSchema, changePasswordSchema } from './user.schema.js';
+import { createUserSchema, changeUserRoleSchema, changePasswordSchema, loginUserSchema } from './user.schema.js';
 import { authenticateToken } from '../../middleware/authentication.js';
 import { authorizeRoles } from '../../middleware/authorizeRoles.js';
 import { loginRateLimiter, registerRateLimiter } from '../../middleware/rateLimit.js';
@@ -12,7 +12,7 @@ export function registerUserRoutes(app: Application): void {
     const userController = new UserController();
 
     router.post('/api/users/register', registerRateLimiter, requireRegistrationEnabled, validate(createUserSchema), userController.register);
-    router.post('/api/users/login', loginRateLimiter, userController.login);
+    router.post('/api/users/login', loginRateLimiter, validate(loginUserSchema), userController.login);
     router.post('/api/users/logout', userController.logout);
 
     router.get('/api/users', authenticateToken, authorizeRoles("admin", "superadmin"), userController.getPublicUsers);

--- a/BE/src/modules/user/user.schema.ts
+++ b/BE/src/modules/user/user.schema.ts
@@ -13,6 +13,11 @@ export const createUserSchema = z.object({
     email: z.string().email({ message: "Invalid email address" }),
 });
 
+export const loginUserSchema = z.object({
+    username: z.string().min(1, { message: "Username is required" }),
+    password: z.string().min(1, { message: "Password is required" }),
+});
+
 export const changePasswordSchema = z.object({
     currentPassword: z.string().min(1, { message: "Current password is required" }),
     newPassword: passwordSchema,


### PR DESCRIPTION
## Summary
- Add `loginUserSchema` requiring non-empty `username` and `password`.
- Apply `validate(loginUserSchema)` on `POST /api/users/login` (same pattern as register).

## Why
Register already validates with Zod; login accepted any body shape and deferred failures to the service.

## Test plan
- [ ] Valid login still returns a token/cookie
- [ ] `{}` or missing password returns 400 from validation middleware
- [ ] Rate limiter still applies before/with validation

Made with [Cursor](https://cursor.com)