### PR TITLE
feat(be): rate-limit public trivia routes

### DIFF
--- a/BE/src/middleware/rateLimit.ts
+++ b/BE/src/middleware/rateLimit.ts
@@ -38,3 +38,11 @@ export const robloxRateLimiter = rateLimit({
     standardHeaders: true,
     legacyHeaders: false,
 });
+
+export const triviaRateLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 60,
+    message: { error: "Too many trivia requests. Please try again later." },
+    standardHeaders: true,
+    legacyHeaders: false,
+});

--- a/BE/src/modules/trivia/trivia.routes.ts
+++ b/BE/src/modules/trivia/trivia.routes.ts
@@ -1,7 +1,6 @@
 import { Application, Router } from 'express';
 import { TriviaController } from './trivia.controller.js';
-import { cacheMiddleware } from '../../middleware/cache.js';
-import { authenticateCombined } from '../../middleware/combinedAuth.js';
+import { triviaRateLimiter } from '../../middleware/rateLimit.js';
 
 /**
  * Register trivia routes with the Express application
@@ -9,6 +8,8 @@ import { authenticateCombined } from '../../middleware/combinedAuth.js';
 export function registerTriviaRoutes(app: Application): void {
     const router = Router();
     const triviaController = new TriviaController();
+
+    router.use(triviaRateLimiter);
 
     // GET routes - PUBLIC (for testing) - NO CACHING for random trivia
     router.get('/player', triviaController.getRandomTriviaPlayer);
@@ -20,4 +21,4 @@ export function registerTriviaRoutes(app: Application): void {
 
     // Register router with prefix
     app.use('/api/trivia', router);
-} 
+}


### PR DESCRIPTION
## Summary
- Add `triviaRateLimiter` (60 req/min) in `rateLimit.ts`.
- Apply it to all `/api/trivia` routes.
- Also drops unused `cacheMiddleware` / `authenticateCombined` imports on that router.

## Why
Trivia is public and cheap to hammer; other public-ish endpoints already have limiters.

## Test plan
- [ ] Normal trivia play still works under the limit
- [ ] Bursting past 60/min returns 429 with the trivia rate-limit message

Made with [Cursor](https://cursor.com)