### PR TITLE
chore(be): remove unused errorHandler import from app.ts

### DIFF
--- a/BE/src/app.ts
+++ b/BE/src/app.ts
@@ -1,7 +1,6 @@
 import express, { Application } from 'express';
 import { registerModules } from './modules/index.js'; // Keep .js extension for TypeScript
 import { globalMiddleware } from './middleware/globalMiddleware.js';
-import { errorHandler } from './middleware/errorHandling.js';
 
 /**
  * Create and configure an Express application


### PR DESCRIPTION
## Summary
- Drop the unused `errorHandler` import from `createApp`.

## Why
Error handling is wired in `server.ts`. The unused import in `app.ts` was misleading.

## Test plan
- [ ] Server still starts and errors still hit the global handler

Made with [Cursor](https://cursor.com)