### PR TITLE
refactor(be): typed ConflictError for article like/unlike

### DIFF
--- a/BE/src/modules/articles/article.controller.ts
+++ b/BE/src/modules/articles/article.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { ArticleService, ArticleFilters } from './article.service.js';
 import { MissingFieldError } from '../../errors/MissingFieldError.js';
 import { NotFoundError } from '../../errors/NotFoundError.js';
+import { ConflictError } from '../../errors/ConflictError.js';
 import { parsePagination, toPaginatedResult } from '../../utils/pagination.js';
 
 const ARTICLES_DEFAULT_LIMIT = 10;
@@ -161,7 +162,7 @@ export class ArticleController {
         } catch (error) {
             if (error instanceof MissingFieldError || error instanceof NotFoundError) {
                 res.status(400).json({ message: error.message });
-            } else if (error instanceof Error && error.message.includes("already liked")) {
+            } else if (error instanceof ConflictError) {
                 res.status(409).json({ message: error.message });
             } else {
                 res.status(500).json({ message: 'Internal server error' });
@@ -182,7 +183,7 @@ export class ArticleController {
         } catch (error) {
             if (error instanceof MissingFieldError || error instanceof NotFoundError) {
                 res.status(400).json({ message: error.message });
-            } else if (error instanceof Error && error.message.includes("not liked")) {
+            } else if (error instanceof ConflictError) {
                 res.status(409).json({ message: error.message });
             } else {
                 res.status(500).json({ message: 'Internal server error' });

--- a/BE/src/modules/articles/article.service.ts
+++ b/BE/src/modules/articles/article.service.ts
@@ -4,6 +4,7 @@ import { Article } from './article.entity.js';
 import { User } from '../user/user.entity.js';
 import { MissingFieldError } from '../../errors/MissingFieldError.js';
 import { NotFoundError } from '../../errors/NotFoundError.js';
+import { ConflictError } from '../../errors/ConflictError.js';
 import { PaginationParams } from '../../utils/pagination.js';
 
 export interface ArticleFilters {
@@ -182,7 +183,7 @@ export class ArticleService {
             // Check if user already liked this article
             const hasLiked = article.likedBy?.some(likedUser => likedUser.id === userId);
             if (hasLiked) {
-                throw new Error("User has already liked this article");
+                throw new ConflictError("User has already liked this article");
             }
 
             // Add user to likedBy array
@@ -220,7 +221,7 @@ export class ArticleService {
             // Check if user has liked this article
             const hasLiked = article.likedBy?.some(likedUser => likedUser.id === userId);
             if (!hasLiked) {
-                throw new Error("User has not liked this article");
+                throw new ConflictError("User has not liked this article");
             }
 
             // Remove user from likedBy array


### PR DESCRIPTION
## Summary
- Throw `ConflictError` from article like/unlike when the like state is invalid.
- Controllers use `instanceof ConflictError` instead of `message.includes(...)`.

## Why
String matching on error messages is brittle and inconsistent with the rest of the domain error hierarchy.

## Test plan
- [ ] Like an article twice → 409
- [ ] Unlike without liking → 409
- [ ] Normal like/unlike still 200

Made with [Cursor](https://cursor.com)