### PR TITLE
fix(fe): privacy policy typo (hte → the)

### DIFF
--- a/FE/src/components/PrivacyPolicy.tsx
+++ b/FE/src/components/PrivacyPolicy.tsx
@@ -105,7 +105,7 @@ const PrivacyPolicy: React.FC = () =>
             <section className="privacy-section">
                 <h2 className="section-title">Contact Us</h2>
                 <p>
-                    If you have any questions about this Privacy Policy or our data practices, please contact us through our contact page in hte footer below. We will respond to your inquiry as soon as possible.
+                    If you have any questions about this Privacy Policy or our data practices, please contact us through our contact page in the footer below. We will respond to your inquiry as soon as possible.
                 </p>
             </section>
         </div>


### PR DESCRIPTION
## Summary
- Fix `hte` → `the` in the Privacy Policy contact section.

## Test plan
- [ ] Open `/privacy-policy` and confirm the sentence reads correctly

Made with [Cursor](https://cursor.com)