### PR TITLE
fix(fe): point Help Center link to /faq

### DIFF
--- a/FE/src/components/ContactUs.tsx
+++ b/FE/src/components/ContactUs.tsx
@@ -36,7 +36,7 @@ const Contact: React.FC = () =>
                 <h2>Help Center</h2>
                 <p>Still not sure who to contact? Browse our help center and find quick answers.</p>
                 <a
-                    href="/help"
+                    href="/faq"
                     className="contact-button"
                 >
                     Visit Help Center


### PR DESCRIPTION
## Summary
- Change Contact page Help Center `href` from `/help` (missing route) to `/faq`.

## Why
The CTA was a dead link; FAQ is the existing help content page.

## Test plan
- [ ] From `/contact`, click Visit Help Center → lands on FAQ

Made with [Cursor](https://cursor.com)