### PR TITLE
fix(fe): clarify navbar Discord vs Play Now labels

### DIFF
--- a/FE/src/components/NavBar.tsx
+++ b/FE/src/components/NavBar.tsx
@@ -13,13 +13,13 @@ const Navbar: React.FC = () =>
                 {/* Left-aligned nav list */}
                 <ul className="navbar-links">
                     <li>
-                        {/* External link to the RVL game */}
+                        {/* External link to the Discord server */}
                         <a href="https://discord.gg/volleyball" target="_blank" rel="noopener noreferrer">
-                            Roblox Volleyball League
+                            Join Discord
                         </a>
                     </li>
                     <li>
-                        {/* External link to the Discord server */}
+                        {/* External link to the RVL game */}
                         <a href="https://www.roblox.com/games/3840352284/Volleyball-4-2" target="_blank" rel="noopener noreferrer">
                             Play Now
                         </a>


### PR DESCRIPTION
## Summary
- Rename `Roblox Volleyball League` (Discord invite) to `Join Discord`.
- Fix swapped HTML comments so they match the actual destinations.

## Why
Visible label and comments disagreed with where each link goes, which confuses users and future editors.

## Test plan
- [ ] Join Discord opens discord.gg/volleyball
- [ ] Play Now opens the Roblox game URL

Made with [Cursor](https://cursor.com)