### PR TITLE
a11y(fe): add aria-label to SearchBar input

### DIFF
--- a/FE/src/components/Searchbar.tsx
+++ b/FE/src/components/Searchbar.tsx
@@ -22,6 +22,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ onSearch, placeholder = "Search..
             <input
                 type="text"
                 placeholder={placeholder}
+                aria-label={placeholder}
                 value={query}
                 onChange={handleInputChange}
             />


### PR DESCRIPTION
## Summary
- Set `aria-label={placeholder}` on the shared SearchBar `<input>`.

## Why
Placeholder-only inputs are often skipped or poorly announced by assistive tech.

## Test plan
- [ ] Search still works on listing/portal pages
- [ ] Inspect input: aria-label matches placeholder text

Made with [Cursor](https://cursor.com)