### PR TITLE
a11y(fe): Modal Escape key and dialog semantics

### DIFF
--- a/FE/src/components/ui/Modal.tsx
+++ b/FE/src/components/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import "./ui.css";
 
 interface ModalProps {
@@ -10,12 +10,28 @@ interface ModalProps {
 }
 
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, className }) => {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   return (
     <div className="ui-modal-overlay" onClick={onClose}>
       <div
         className={className ? `ui-modal ${className}` : "ui-modal"}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="ui-modal-header">


### PR DESCRIPTION
﻿## Summary
- Add role=dialog, aria-modal, and aria-label from the title.
- Close the modal when Escape is pressed while open.

## Why
Overlay click alone is not enough for keyboard users; dialogs should be announced and dismissible via Escape.

## Test plan
- [ ] Open any modal, press Escape, confirm it closes
- [ ] Overlay click and Close button still work
- [ ] Screen reader announces dialog when opened
