### PR TITLE
a11y(fe): FAQ accordion aria-controls

### DIFF
--- a/FE/src/components/FAQ.tsx
+++ b/FE/src/components/FAQ.tsx
@@ -260,12 +260,13 @@ const FAQ: React.FC = () => {
                                             className="faq-question"
                                             onClick={() => toggleItem(item.id)}
                                             aria-expanded={openItems.has(item.id)}
+                                            aria-controls={`faq-answer-${item.id}`}
                                         >
                                             <span>{item.question}</span>
                                             {openItems.has(item.id) ? <FaChevronUp /> : <FaChevronDown />}
                                         </button>
                                         {openItems.has(item.id) && (
-                                            <div className="faq-answer">
+                                            <div className="faq-answer" id={`faq-answer-${item.id}`}>
                                                 {item.answer}
                                             </div>
                                         )}


### PR DESCRIPTION
﻿## Summary
- Add stable answer panel ids and aria-controls on FAQ question buttons.

## Why
Buttons already expose aria-expanded but were not associated with their answer panels.

## Test plan
- [ ] Expand/collapse FAQ items still works
- [ ] Inspect DOM: button aria-controls matches answer id
