### PR TITLE
fix(fe): PrivateRoute loading UI instead of blank

### DIFF
--- a/FE/src/components/portal/PrivateRoute.tsx
+++ b/FE/src/components/portal/PrivateRoute.tsx
@@ -14,7 +14,7 @@ interface PrivateRouteProps {
 export default function PrivateRoute({ roles, children }: PrivateRouteProps) {
   const { user, isAuthenticated, loading } = useAuth();
 
-  if (loading) return null;
+  if (loading) return <div className="page-loading" role="status">Loading…</div>;
   if (!isAuthenticated || !user) return <Navigate to="/login" replace />;
   if (!roles.includes(user.role as AllowedRole)) return <Navigate to="/" replace />;
 


### PR DESCRIPTION
﻿## Summary
- Return a Loading status UI while auth is loading instead of null.

## Why
Returning null caused a blank flash on portal routes before redirect or content.

## Test plan
- [ ] Hard refresh a portal URL while logged in — brief Loading, then content
- [ ] Logged-out users still redirect to /login
