### PR TITLE
chore(fe): strip trivia debug logs from useFetch

### DIFF
--- a/FE/src/hooks/useFetch.ts
+++ b/FE/src/hooks/useFetch.ts
@@ -63,19 +63,16 @@ export const useFetchTeamByName = <T>(teamName: string) =>
 
 export const useFetchGameById = <T>(gameId: string) =>
 {
-    console.log(`Use fetch called using games/${gameId}`);
     return useFetch<T>(`games/${gameId}`);  // Always treats result as an array
 };
 
 export const useFetchSeasonById = <T>(seasonId: string) =>
 {
-    console.log(`Use fetch called using seasons/${seasonId}`);
     return useFetch<T>(`seasons/${seasonId}`);  // Always treats result as an array
 };
 
 export const useFetchArticleById = <T>(articleId: string) =>
     {
-        console.log(`Use fetch called using articles/${articleId}`);
         return useFetch<T>(`articles/${articleId}`);  // Always treats result as an array
     };
 
@@ -146,48 +143,35 @@ export const useTriviaPlayer = (difficulty: 'easy' | 'medium' | 'hard' | 'imposs
 
   const fetchTriviaPlayer = async () => {
     if (!difficulty) {
-      console.error('❌ [useTriviaPlayer] No difficulty provided');
+      console.error('useTriviaPlayer: difficulty is required');
       setError('Difficulty is required');
       return null;
     }
 
-    console.log('🔍 [useTriviaPlayer] Starting fetch with difficulty:', difficulty);
     setLoading(true);
     setError(null);
     
     try {
-      console.log('🔍 [useTriviaPlayer] Making fetch request...');
       const res = await authFetch(`${backendUrl}/api/trivia/player?difficulty=${difficulty}`, {
         method: 'GET'
       });
       
-      console.log('🔍 [useTriviaPlayer] Response status:', res.status);
-      console.log('🔍 [useTriviaPlayer] Response headers:', Object.fromEntries(res.headers.entries()));
       
       if (!res.ok) {
-        console.error('❌ [useTriviaPlayer] Response not OK:', res.status, res.statusText);
         const errorText = await res.text();
-        console.error('❌ [useTriviaPlayer] Error response body:', errorText);
+        console.error("Failed to fetch trivia player", res.status, errorText);
         throw new Error(`Failed to fetch trivia player: ${res.status} ${res.statusText}`);
       }
       
-      console.log('🔍 [useTriviaPlayer] Parsing JSON response...');
       const result = await res.json();
-      console.log('✅ [useTriviaPlayer] Successfully fetched trivia player:', result);
       
       setData(result);
       return result;
     } catch (err: any) {
-      console.error('❌ [useTriviaPlayer] Fetch error:', err);
-      console.error('❌ [useTriviaPlayer] Error details:', {
-        message: err.message,
-        stack: err.stack,
-        name: err.name
-      });
+      console.error("useTriviaPlayer fetch failed", err);
       setError(err.message || 'Unknown error');
       return null;
     } finally {
-      console.log('🔍 [useTriviaPlayer] Setting loading to false');
       setLoading(false);
     }
   };
@@ -211,48 +195,35 @@ export const useTriviaTeam = (difficulty: 'easy' | 'medium' | 'hard' | 'impossib
 
   const fetchTriviaTeam = async () => {
     if (!difficulty) {
-      console.error('❌ [useTriviaTeam] No difficulty provided');
+      console.error('useTriviaTeam: difficulty is required');
       setError('Difficulty is required');
       return null;
     }
 
-    console.log('🔍 [useTriviaTeam] Starting fetch with difficulty:', difficulty);
     setLoading(true);
     setError(null);
     
     try {
-      console.log('🔍 [useTriviaTeam] Making fetch request...');
       const res = await authFetch(`${backendUrl}/api/trivia/team?difficulty=${difficulty}`, {
         method: 'GET'
       });
       
-      console.log('🔍 [useTriviaTeam] Response status:', res.status);
-      console.log('🔍 [useTriviaTeam] Response headers:', Object.fromEntries(res.headers.entries()));
       
       if (!res.ok) {
-        console.error('❌ [useTriviaTeam] Response not OK:', res.status, res.statusText);
         const errorText = await res.text();
-        console.error('❌ [useTriviaTeam] Error response body:', errorText);
+        console.error("Failed to fetch trivia team", res.status, errorText);
         throw new Error(`Failed to fetch trivia team: ${res.status} ${res.statusText}`);
       }
       
-      console.log('🔍 [useTriviaTeam] Parsing JSON response...');
       const result = await res.json();
-      console.log('✅ [useTriviaTeam] Successfully fetched trivia team:', result);
       
       setData(result);
       return result;
     } catch (err: any) {
-      console.error('❌ [useTriviaTeam] Fetch error:', err);
-      console.error('❌ [useTriviaTeam] Error details:', {
-        message: err.message,
-        stack: err.stack,
-        name: err.name
-      });
+      console.error("useTriviaTeam fetch failed", err);
       setError(err.message || 'Unknown error');
       return null;
     } finally {
-      console.log('🔍 [useTriviaTeam] Setting loading to false');
       setLoading(false);
     }
   };
@@ -276,48 +247,35 @@ export const useTriviaSeason = (difficulty: 'easy' | 'medium' | 'hard' | 'imposs
 
   const fetchTriviaSeason = async () => {
     if (!difficulty) {
-      console.error('❌ [useTriviaSeason] No difficulty provided');
+      console.error('useTriviaSeason: difficulty is required');
       setError('Difficulty is required');
       return null;
     }
 
-    console.log('🔍 [useTriviaSeason] Starting fetch with difficulty:', difficulty);
     setLoading(true);
     setError(null);
     
     try {
-      console.log('🔍 [useTriviaSeason] Making fetch request...');
       const res = await authFetch(`${backendUrl}/api/trivia/season?difficulty=${difficulty}`, {
         method: 'GET'
       });
       
-      console.log('🔍 [useTriviaSeason] Response status:', res.status);
-      console.log('🔍 [useTriviaSeason] Response headers:', Object.fromEntries(res.headers.entries()));
       
       if (!res.ok) {
-        console.error('❌ [useTriviaSeason] Response not OK:', res.status, res.statusText);
         const errorText = await res.text();
-        console.error('❌ [useTriviaSeason] Error response body:', errorText);
+        console.error("Failed to fetch trivia season", res.status, errorText);
         throw new Error(`Failed to fetch trivia season: ${res.status} ${res.statusText}`);
       }
       
-      console.log('🔍 [useTriviaSeason] Parsing JSON response...');
       const result = await res.json();
-      console.log('✅ [useTriviaSeason] Successfully fetched trivia season:', result);
       
       setData(result);
       return result;
     } catch (err: any) {
-      console.error('❌ [useTriviaSeason] Fetch error:', err);
-      console.error('❌ [useTriviaSeason] Error details:', {
-        message: err.message,
-        stack: err.stack,
-        name: err.name
-      });
+      console.error("useTriviaSeason fetch failed", err);
       setError(err.message || 'Unknown error');
       return null;
     } finally {
-      console.log('🔍 [useTriviaSeason] Setting loading to false');
       setLoading(false);
     }
   };
@@ -344,50 +302,36 @@ export const useSubmitTriviaGuess = () => {
     id: number,
     guess: string
   ) => {
-    console.log('🔍 [useSubmitTriviaGuess] Starting guess submission:', { type, id, guess });
     
     setLoading(true);
     setError(null);
     
     const requestBody = { type, id, guess };
     
-    console.log('🔍 [useSubmitTriviaGuess] Request body:', requestBody);
     
     try {
-      console.log('🔍 [useSubmitTriviaGuess] Making POST request...');
       const res = await authFetch(`${backendUrl}/api/trivia/guess`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody)
       });
       
-      console.log('🔍 [useSubmitTriviaGuess] Response status:', res.status);
-      console.log('🔍 [useSubmitTriviaGuess] Response headers:', Object.fromEntries(res.headers.entries()));
       
       if (!res.ok) {
-        console.error('❌ [useSubmitTriviaGuess] Response not OK:', res.status, res.statusText);
         const errorText = await res.text();
-        console.error('❌ [useSubmitTriviaGuess] Error response body:', errorText);
+        console.error("Failed to submit trivia guess", res.status, errorText);
         throw new Error(`Failed to submit guess: ${res.status} ${res.statusText}`);
       }
       
-      console.log('🔍 [useSubmitTriviaGuess] Parsing JSON response...');
       const data = await res.json();
-      console.log('✅ [useSubmitTriviaGuess] Successfully submitted guess:', data);
       
       setResult(data);
       return data;
     } catch (err: any) {
-      console.error('❌ [useSubmitTriviaGuess] Submit error:', err);
-      console.error('❌ [useSubmitTriviaGuess] Error details:', {
-        message: err.message,
-        stack: err.stack,
-        name: err.name
-      });
+      console.error("useSubmitTriviaGuess failed", err);
       setError(err.message || 'Unknown error');
       return null;
     } finally {
-      console.log('🔍 [useSubmitTriviaGuess] Setting loading to false');
       setLoading(false);
     }
   };


### PR DESCRIPTION
﻿## Summary
- Remove emoji/debug console.log spam from trivia hooks and by-id fetch helpers.
- Keep short console.error messages on real failures.

## Why
Trivia play was flooding the browser console on every request, which hurts debugging real issues.

## Test plan
- [ ] Trivia player/team/season fetch and guess still work
- [ ] Console stays quiet on success; errors still log on failure
