### PR TITLE
ux(fe): empty state for Teams listing

### DIFF
--- a/FE/src/components/Teams.tsx
+++ b/FE/src/components/Teams.tsx
@@ -159,6 +159,8 @@ const Teams: React.FC = () =>
                         ))}
                     </div>
                 </div>
+            ) : (paginatedTeams ?? []).length === 0 ? (
+                <div className="listing-table-empty">No teams match your filters.</div>
             ) : (
                 <div className="teams-wrapper">
                     <div className="teams-container">


### PR DESCRIPTION
﻿## Summary
- When teams finish loading with zero results, show \"No teams match your filters.\"

## Why
Players already had this; Teams silently rendered an empty grid.

## Test plan
- [ ] Filter to something with no matches — empty message appears
- [ ] Normal results still show team cards
