### PR TITLE
a11y(fe): use Link for Login/SignUp cross-links

### DIFF
--- a/FE/src/components/Login.tsx
+++ b/FE/src/components/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useLogin } from "../hooks/useLogin";
 import "../styles/Login.css";
 
@@ -57,9 +57,9 @@ const LoginPage: React.FC = () =>
             </form>
             <p>
                 Don’t have an account?{" "}
-                <span className="auth-link" onClick={() => navigate("/signup")}>
+                <Link className="auth-link" to="/signup">
                     Sign up
-                </span>
+                </Link>
             </p>
         </div>
     );

--- a/FE/src/components/SignUp.tsx
+++ b/FE/src/components/SignUp.tsx
@@ -1,6 +1,6 @@
 // src/pages/SignupPage.tsx
 import React, { useState } from "react";
-import { useNavigate }        from "react-router-dom";
+import { Link, useNavigate }        from "react-router-dom";
 import { useSignup }          from "../hooks/useSignUp";
 import "../styles/Login.css";
 
@@ -98,12 +98,9 @@ const SignupPage: React.FC = () =>
 
             <p>
                 Already have an account?{' '}
-                <span
-                    className="auth-link"
-                    onClick={() => navigate("/login")}
-                >
+                <Link className="auth-link" to="/login">
                     Log in
-                </span>
+                </Link>
             </p>
         </div>
     );


### PR DESCRIPTION
﻿## Summary
- Replace span+onClick auth cross-links with React Router Link on Login and SignUp.

## Why
Clickable spans are not focusable or activatable via keyboard by default.

## Test plan
- [ ] Tab to Sign up / Log in links and activate with Enter
- [ ] Links still navigate correctly
