### PR TITLE
a11y(fe): Header guest dropdown Escape and ARIA

### DIFF
--- a/FE/src/components/Header.tsx
+++ b/FE/src/components/Header.tsx
@@ -22,7 +22,7 @@ const Header: React.FC = () =>
     // toggle dropdown when button is clicked
     const toggleDropdown = () => setDropdownOpen(!dropdownOpen);
 
-    // close dropdown when clicking outside
+    // close dropdown when clicking outside or pressing Escape
     useEffect(() =>
     {
         const handleClickOutside = (event: MouseEvent) =>
@@ -33,8 +33,20 @@ const Header: React.FC = () =>
             }
         };
 
+        const handleKeyDown = (event: KeyboardEvent) =>
+        {
+            if (event.key === "Escape")
+            {
+                setDropdownOpen(false);
+            }
+        };
+
         document.addEventListener("mousedown", handleClickOutside);
-        return () => document.removeEventListener("mousedown", handleClickOutside);
+        document.addEventListener("keydown", handleKeyDown);
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+            document.removeEventListener("keydown", handleKeyDown);
+        };
     }, []);
 
     return (
@@ -68,17 +80,23 @@ const Header: React.FC = () =>
                     </div>
                 ) : (
                     // guest dropdown when not logged in
-                    <div className="auth-dropdown">
+                    <div className="auth-dropdown" ref={dropdownRef}>
                         <div className="auth-button-wrapper">
                             <span className="auth-text">Guest</span>
-                            <button onClick={toggleDropdown} className="dropdown-btn">
+                            <button
+                                onClick={toggleDropdown}
+                                className="dropdown-btn"
+                                aria-expanded={dropdownOpen}
+                                aria-haspopup="menu"
+                                aria-label="Account menu"
+                            >
                                 ☰
                             </button>
                         </div>
                         {dropdownOpen && (
-                            <div ref={dropdownRef} className="dropdown-menu">
-                                <Link to="/login">Login</Link>
-                                <Link to="/signup">Sign Up</Link>
+                            <div className="dropdown-menu" role="menu">
+                                <Link to="/login" role="menuitem" onClick={() => setDropdownOpen(false)}>Login</Link>
+                                <Link to="/signup" role="menuitem" onClick={() => setDropdownOpen(false)}>Sign Up</Link>
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
﻿## Summary
- Add aria-expanded, aria-haspopup, and aria-label on the guest menu button.
- Close on Escape; mark menu/menuitem roles.
- Move outside-click ref to the dropdown wrapper so the toggle stays inside the click boundary.

## Test plan
- [ ] Open guest menu, press Escape — closes
- [ ] Click outside — closes
- [ ] Login/Sign Up links still work
