### PR TITLE
fix(fe): accessible Suspense loading fallback styles

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -60,7 +60,7 @@ const App: React.FC = () => (
       <Navbar />
 
       <div className="main-content">
-        <Suspense fallback={<div className="page-loading" />}>
+        <Suspense fallback={<div className="page-loading" role="status">Loading…</div>}>
         <Routes>
           {/* public site */}
           <Route path="/" element={<Home />} />

--- a/FE/src/styles/App.css
+++ b/FE/src/styles/App.css
@@ -119,3 +119,14 @@ body {
   position: relative;
   flex-shrink: 0; /* Prevent it from shrinking */
 }
+
+/* Route-level Suspense fallback */
+.page-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40vh;
+  padding: 2rem;
+  color: #555;
+  font-size: 1rem;
+}


### PR DESCRIPTION
﻿## Summary
- Add .page-loading styles in App.css.
- Suspense fallback now shows \"Loading…\" with role=status.

## Why
The fallback div used a class that did not exist, so route transitions showed a blank content area.

## Test plan
- [ ] Navigate between lazy routes and see a brief Loading indicator
