### PR TITLE
refactor(fe): share portal TEAM_PLACEMENT_OPTIONS constant

### DIFF
--- a/FE/src/components/portal/TeamsPage.tsx
+++ b/FE/src/components/portal/TeamsPage.tsx
@@ -17,6 +17,7 @@ import FilterBar from "../ui/FilterBar";
 import Table, { type TableColumn } from "../ui/Table";
 import RegionSeasonFields from "../ui/RegionSeasonFields";
 import { useFormRegionSeason } from "../../hooks/useFormRegionSeason";
+import { TEAM_PLACEMENT_OPTIONS } from "../../constants/teamPlacements";
 
 type EditField =
   | "name"
@@ -33,29 +34,6 @@ interface EditingState {
 interface TeamTableColumn extends TableColumn<Team> {}
 
 const TEAMS_PER_PAGE = 10;
-
-const TEAM_PLACEMENT_OPTIONS = [
-  "Didnt make playoffs",
-  "TBD",
-  "1st Place",
-  "1st Place (D1)",
-  "1st Place (D2)",
-  "1st Place (D3)",
-  "2nd Place",
-  "2nd Place (D1)",
-  "2nd Place (D2)",
-  "2nd Place (D3)",
-  "3rd Place",
-  "3rd Place (D1)",
-  "3rd Place (D2)",
-  "3rd Place (D3)",
-  "Top 4",
-  "Top 6",
-  "Top 8",
-  "Top 12",
-  "Top 16",
-  "G.O.A.T.",
-] as const;
 
 const TeamsPage: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState<string>("");

--- a/FE/src/constants/teamPlacements.ts
+++ b/FE/src/constants/teamPlacements.ts
@@ -12,3 +12,27 @@ export const TEAM_PLACEMENTS = [
   "Didnt make playoffs",
   "G.O.A.T.",
 ] as const;
+
+/** Full placement options for admin create/edit forms (includes division variants). */
+export const TEAM_PLACEMENT_OPTIONS = [
+  "Didnt make playoffs",
+  "TBD",
+  "1st Place",
+  "1st Place (D1)",
+  "1st Place (D2)",
+  "1st Place (D3)",
+  "2nd Place",
+  "2nd Place (D1)",
+  "2nd Place (D2)",
+  "2nd Place (D3)",
+  "3rd Place",
+  "3rd Place (D1)",
+  "3rd Place (D2)",
+  "3rd Place (D3)",
+  "Top 4",
+  "Top 6",
+  "Top 8",
+  "Top 12",
+  "Top 16",
+  "G.O.A.T.",
+] as const;


### PR DESCRIPTION
﻿## Summary
- Export TEAM_PLACEMENT_OPTIONS from constants/teamPlacements.ts.
- Import it in portal TeamsPage instead of a local duplicate list.

## Why
Placement strings lived in two places; portal had a longer list that was easy to diverge from public filters.

## Test plan
- [ ] Portal create/edit team placement dropdown still lists all options
- [ ] Public Teams filter still uses TEAM_PLACEMENTS unchanged
