### PR TITLE
refactor(be): typed domain errors for records module

### DIFF
--- a/BE/src/modules/records/records.controller.ts
+++ b/BE/src/modules/records/records.controller.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from 'express';
 import { MissingFieldError } from '../../errors/MissingFieldError.js';
 import { NotFoundError } from '../../errors/NotFoundError.js';
+import { OutOfBoundsError } from '../../errors/OutOfBoundsError.js';
+import { DuplicateError } from '../../errors/DuplicateError.js';
 import { RecordService, RecordFilters } from './records.service.js';
 import { parsePagination, toPaginatedResult } from '../../utils/pagination.js';
 import { parseRegionQuery } from '../../utils/regionQuery.js';
@@ -29,14 +31,13 @@ export class RecordController {
             
             res.status(201).json(savedRecord);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to create record";
-            
-            if (errorMessage.includes("required") || 
-                errorMessage.includes("not found") || 
-                errorMessage.includes("already exists") ||
-                errorMessage.includes("must be") ||
-                errorMessage.includes("between")) {
-                res.status(400).json({ error: errorMessage });
+            if (
+                error instanceof MissingFieldError ||
+                error instanceof NotFoundError ||
+                error instanceof OutOfBoundsError ||
+                error instanceof DuplicateError
+            ) {
+                res.status(error.statusCode).json({ error: error.message });
             } else {
                 console.error("Error creating record:", error);
                 res.status(500).json({ error: "Failed to create record" });
@@ -146,14 +147,12 @@ export class RecordController {
             const updatedRecord = await this.recordService.updateRecord(id, updateData);
             res.json(updatedRecord);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to update record";
-            
-            if (error instanceof MissingFieldError) {
-                res.status(400).json({ error: errorMessage });
-            } else if (error instanceof NotFoundError) {
-                res.status(404).json({ error: errorMessage });
-            } else if (errorMessage.includes("must be between")) {
-                res.status(400).json({ error: errorMessage });
+            if (
+                error instanceof MissingFieldError ||
+                error instanceof NotFoundError ||
+                error instanceof OutOfBoundsError
+            ) {
+                res.status(error.statusCode).json({ error: error.message });
             } else {
                 console.error("Error updating record:", error);
                 res.status(500).json({ error: "Failed to update record" });
@@ -208,10 +207,8 @@ export class RecordController {
             const result = await this.recordService.calculateAllRecords();
             res.json(result);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to calculate records";
-            
-            if (errorMessage.includes("No stats found")) {
-                res.status(400).json({ error: errorMessage });
+            if (error instanceof NotFoundError) {
+                res.status(error.statusCode).json({ error: error.message });
             } else {
                 console.error("Error calculating records:", error);
                 res.status(500).json({ error: "Failed to calculate records" });

--- a/BE/src/modules/records/records.service.ts
+++ b/BE/src/modules/records/records.service.ts
@@ -6,6 +6,8 @@ import { Seasons } from '../seasons/season.entity.js';
 import { Stats } from '../stats/stat.entity.js';
 import { MissingFieldError } from '../../errors/MissingFieldError.js';
 import { NotFoundError } from '../../errors/NotFoundError.js';
+import { OutOfBoundsError } from '../../errors/OutOfBoundsError.js';
+import { DuplicateError } from '../../errors/DuplicateError.js';
 import { CreateRecordDto, UpdateRecordDto } from './records.schema.js';
 import { PaginationParams } from '../../utils/pagination.js';
 
@@ -42,7 +44,7 @@ export class RecordService {
 
         // Validate rank range
         if (recordData.rank < 1 || recordData.rank > 10) {
-            throw new Error("Rank must be between 1 and 10");
+            throw new OutOfBoundsError("Rank must be between 1 and 10");
         }
 
         // Fetch the player
@@ -66,7 +68,7 @@ export class RecordService {
         });
 
         if (existingRecord) {
-            throw new Error(`Record already exists for ${recordData.record} (${recordData.type}) at rank ${recordData.rank} in season ${recordData.seasonId}`);
+            throw new DuplicateError(`Record already exists for ${recordData.record} (${recordData.type}) at rank ${recordData.rank} in season ${recordData.seasonId}`);
         }
 
         // Create new record
@@ -186,7 +188,7 @@ export class RecordService {
         if (updateData.type !== undefined) record.type = updateData.type;
         if (updateData.rank !== undefined) {
             if (updateData.rank < 1 || updateData.rank > 10) {
-                throw new Error("Rank must be between 1 and 10");
+                throw new OutOfBoundsError("Rank must be between 1 and 10");
             }
             record.rank = updateData.rank;
         }
@@ -254,7 +256,7 @@ export class RecordService {
         });
 
         if (stats.length === 0) {
-            throw new Error("No stats found in the database");
+            throw new NotFoundError("No stats found in the database");
         }
 
         let recordsCreated = 0;


### PR DESCRIPTION
﻿## Summary
- Throw OutOfBoundsError, DuplicateError, and NotFoundError from records service.
- Controllers use instanceof + error.statusCode instead of message string matching.

## Note
Status codes become more accurate (e.g. duplicate → 409, missing stats → 404) vs previous blanket 400s.

## Test plan
- [ ] Create record with rank 0 → client error (422)
- [ ] Duplicate create → 409
- [ ] Calculate with empty stats → 404
- [ ] Happy-path create/update still works
