### PR TITLE
fix(be): correct TypeORM logging startup message

### DIFF
--- a/BE/src/db/data-source.ts
+++ b/BE/src/db/data-source.ts
@@ -70,7 +70,11 @@ export async function initializeDataSource(): Promise<DataSource> {
         if (!AppDataSource.isInitialized) {
             await AppDataSource.initialize();
             console.log("Database connection established");
-            console.log("TypeORM logging enabled for: error, warn, query, schema, migration, info");
+            const logging = AppDataSource.options.logging;
+            console.log(
+              "TypeORM logging enabled for:",
+              Array.isArray(logging) ? logging.join(", ") : String(logging)
+            );
         }
         return AppDataSource;
     } catch (error) {


### PR DESCRIPTION
﻿## Summary
- Print the actual TypeORM `logging` option values on init instead of a hard-coded incorrect list.

## Why
The old message claimed query/schema logging was on, which did not match `data-source.ts` and misled debugging.

## Test plan
- [ ] Start BE in development — log lists error, warn, migration
- [ ] Production config still only reports error (or whatever is configured)
