### PR TITLE
refactor(be): re-export authenticateCombined from authenticateToken

### DIFF
--- a/BE/src/middleware/combinedAuth.ts
+++ b/BE/src/middleware/combinedAuth.ts
@@ -1,37 +1,5 @@
-import { Request, Response, NextFunction } from "express";
-import jwt from "jsonwebtoken";
-import { UnauthorizedError } from "../errors/UnauthorizedError.js";
-import { getJwtSecret, validateJwtPayload, VerifiedJwtUser } from "./authValidation.js";
-import { extractAuthToken } from "./authCookie.js";
-
-export type JwtPayload = VerifiedJwtUser;
-
-export const authenticateCombined = (req: Request, res: Response, next: NextFunction): void =>
-{
-    void (async () =>
-    {
-        try
-        {
-            const token = extractAuthToken(req);
-
-            if (!token)
-            {
-                throw new UnauthorizedError("Authorization token is required");
-            }
-
-            const decoded = jwt.verify(token, getJwtSecret());
-
-            if (!decoded || typeof decoded !== "object")
-            {
-                throw new UnauthorizedError("Invalid or expired token");
-            }
-
-            (req as any).user = await validateJwtPayload(decoded as jwt.JwtPayload);
-            next();
-        }
-        catch (err)
-        {
-            next(err instanceof UnauthorizedError ? err : new UnauthorizedError("Invalid or expired token"));
-        }
-    })();
-};
+/**
+ * Historical alias: authenticateCombined was a duplicate of authenticateToken.
+ * Re-export so existing route imports keep working from one implementation.
+ */
+export { authenticateToken as authenticateCombined, type JwtPayload } from "./authentication.js";


### PR DESCRIPTION
﻿## Summary
- Replace the copy-pasted combinedAuth middleware with a re-export of `authenticateToken`.

## Why
Both files were identical; maintaining two copies risks auth behavior drifting.

## Test plan
- [ ] Admin game/player/article mutations still require auth
- [ ] Like/unlike article still works with Bearer/cookie token
