### PR TITLE
perf(fe): debounce Schedules search API calls

### DIFF
--- a/FE/src/components/Schedules.tsx
+++ b/FE/src/components/Schedules.tsx
@@ -8,6 +8,7 @@ import FilterBar from './ui/FilterBar';
 import { formatGameStage } from '../utils/gameLabels';
 import { isSafeExternalUrl } from '../utils/url';
 import { useRegion } from '../context/regionContext';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import '../styles/Schedules.css';
 
 const Schedules: React.FC = () => {
@@ -17,6 +18,7 @@ const Schedules: React.FC = () => {
   const [selectedSeason, setSelectedSeason] = useState<number | undefined>();
   const [selectedStage, setSelectedStage] = useState<string>('');
   const [searchQuery, setSearchQuery] = useState<string>('');
+  const debouncedSearch = useDebouncedValue(searchQuery, 300);
   const [currentDateRange, setCurrentDateRange] = useState<Date>(new Date());
   const [showLocalTime, setShowLocalTime] = useState<boolean>(false);
   const [collapsedDates, setCollapsedDates] = useState<Set<string>>(new Set());
@@ -30,7 +32,7 @@ const Schedules: React.FC = () => {
     page: 1,
     limit: 500,
     seasonId: selectedSeason,
-    search: searchQuery || undefined,
+    search: debouncedSearch || undefined,
     stage: selectedStage || undefined,
     status: 'scheduled',
     phase: selectedPhase || undefined,


### PR DESCRIPTION
﻿## Summary
- Debounce `searchQuery` with `useDebouncedValue` before passing `search` to `useGames`.

## Why
Schedules was refetching up to 500 games on every keystroke.

## Test plan
- [ ] Type in search — network request waits ~300ms after typing stops
- [ ] Client-side filtering of loaded games still feels immediate
