### PR TITLE
refactor(fe): centralize site URL constants for SEO

### DIFF
--- a/FE/src/components/SEO.tsx
+++ b/FE/src/components/SEO.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Helmet } from '@dr.pogodin/react-helmet';
+import { DEFAULT_OG_IMAGE, DEFAULT_SITE_TITLE, DISCORD_INVITE_URL, ROBLOX_GAME_URL, SITE_URL } from '../constants/site';
 
 interface SEOProps {
   title?: string;
@@ -17,11 +18,11 @@ interface SEOProps {
 }
 
 const SEO: React.FC<SEOProps> = ({
-  title = 'Volleyball 4-2 - Official Roblox Volleyball League',
+  title = DEFAULT_SITE_TITLE,
   description = 'Join the official Roblox Volleyball League (RVL). Watch matches, track player stats, view team rankings, and stay updated with the latest volleyball news and events.',
   keywords = 'volleyball, roblox, RVL, volleyball league, volleyball 4-2, roblox volleyball, competitive volleyball, volleyball stats, volleyball teams, volleyball players',
-  image = 'https://volleyball4-2.com/rvlLogo.png',
-  url = 'https://volleyball4-2.com',
+  image = DEFAULT_OG_IMAGE,
+  url = SITE_URL,
   type = 'website',
   publishedTime,
   modifiedTime,
@@ -30,7 +31,7 @@ const SEO: React.FC<SEOProps> = ({
   tags = [],
   structuredData
 }) => {
-  const fullTitle = title === 'Volleyball 4-2 - Official Roblox Volleyball League' 
+  const fullTitle = title === DEFAULT_SITE_TITLE
     ? title 
     : `${title} | Volleyball 4-2`;
 
@@ -39,14 +40,14 @@ const SEO: React.FC<SEOProps> = ({
     "@type": "SportsOrganization",
     "name": "Roblox Volleyball League",
     "alternateName": "RVL",
-    "url": "https://volleyball4-2.com",
-    "logo": "https://volleyball4-2.com/rvlLogo.png",
+    "url": SITE_URL,
+    "logo": DEFAULT_OG_IMAGE,
     "description": "Official Roblox Volleyball League - Competitive volleyball gaming community",
     "sport": "Volleyball",
     "foundingDate": "2023",
     "sameAs": [
-      "https://discord.gg/volleyball",
-      "https://www.roblox.com/games/3840352284/Volleyball-4-2"
+      DISCORD_INVITE_URL,
+      ROBLOX_GAME_URL
     ]
   };
 

--- a/FE/src/constants/site.ts
+++ b/FE/src/constants/site.ts
@@ -1,0 +1,5 @@
+export const SITE_URL = 'https://volleyball4-2.com';
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/rvlLogo.png`;
+export const DISCORD_INVITE_URL = 'https://discord.gg/volleyball';
+export const ROBLOX_GAME_URL = 'https://www.roblox.com/games/3840352284/Volleyball-4-2';
+export const DEFAULT_SITE_TITLE = 'Volleyball 4-2 - Official Roblox Volleyball League';


### PR DESCRIPTION
﻿## Summary
- Add `FE/src/constants/site.ts` with SITE_URL, OG image, Discord, and Roblox URLs.
- Wire SEO defaults and structured data to those constants.

## Why
Hard-coded site URLs in SEO were easy to drift from NavBar/other call sites.

## Test plan
- [ ] Page titles/meta still render with volleyball4-2.com defaults
- [ ] No runtime behavior change beyond shared constants
