### PR TITLE
chore(be): remove duplicate DB connection log

### DIFF
--- a/BE/src/server.ts
+++ b/BE/src/server.ts
@@ -47,7 +47,6 @@ async function startServer(): Promise<void> {
   try {
     // Initialize TypeORM DataSource
     await initializeDataSource();
-    console.log("Database connection established");
 
     if (process.env.NODE_ENV === 'development') {
       await seedDevData();


### PR DESCRIPTION
﻿## Summary
- Drop the extra Database connection established log from startServer after initializeDataSource.

## Why
Both data-source and server logged the same success line on every boot.

## Test plan
- [ ] Start BE — connection success appears once
