### PR TITLE
chore(fe): strip useCreate success/payload debug logs

### DIFF
--- a/FE/src/hooks/useCreate.ts
+++ b/FE/src/hooks/useCreate.ts
@@ -30,7 +30,6 @@ export const useCreate = <T, U>(endpoint: string) => {
 
         const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
         try {
-            console.log('useCreate: Sending payload to', `${backendUrl}/api/${endpoint}:`, payload);
             const response = await authFetch(
                 `${backendUrl}/api/${endpoint}`,
                 {
@@ -50,7 +49,6 @@ export const useCreate = <T, U>(endpoint: string) => {
             }
 
             const result: T = await response.json();
-            console.log('useCreate: Success response:', result);
             return result;
         } catch (err: any) {
             console.error(`useCreate: Error [${endpoint}]:`, err);


### PR DESCRIPTION
﻿## Summary
- Remove success-path console.log from useCreate (payload + response body).

## Why
Portal creates were dumping request/response payloads into the browser console.

## Test plan
- [ ] Creating a resource in the portal still works
- [ ] Console stays quiet on success
