### PR TITLE
chore(fe): strip Roblox avatar fetch debug logs

### DIFF
--- a/FE/src/utils/fetchAvatarRoblox.ts
+++ b/FE/src/utils/fetchAvatarRoblox.ts
@@ -4,15 +4,12 @@ export async function getRobloxAvatarUrl(username: string): Promise<string | nul
     {
         const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
         
-        // FIXED: Wrapped the URL with backticks
         const url = `${backendUrl}/api/roblox/avatar/${encodeURIComponent(username)}`;
-        console.log('Fetching avatar from URL:', url);
         const res = await fetch(url);
         
         if (!res.ok) return null;
 
         const json = await res.json();
-        console.log('Response data:', json);
         return json.avatarUrl || null;
     }
     catch (e)


### PR DESCRIPTION
﻿## Summary
- Remove console.log from getRobloxAvatarUrl; keep console.error on catch.

## Test plan
- [ ] Avatar fetch still returns a URL or null
