### PR TITLE
docs(fe): add .env.example for Vite backend URL

### DIFF
--- a/FE/.env.example
+++ b/FE/.env.example
@@ -1,0 +1,5 @@
+# Backend API base URL (no trailing slash)
+VITE_BACKEND_URL=http://localhost:3000
+
+# Optional — enable MSW mock API in local FE (see src/mocks)
+# VITE_USE_MSW=true


### PR DESCRIPTION
﻿## Summary
- Add FE/.env.example with VITE_BACKEND_URL (and optional MSW note).

## Test plan
- [ ] Docs-only; copy to .env.local if needed for local FE
