### PR TITLE
feat(fe): ErrorBoundary around route content

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -8,6 +8,7 @@ import Header         from "./components/Header";
 import Navbar         from "./components/NavBar";
 import Footer         from "./components/Footer";
 import PrivateRoute   from "./components/portal/PrivateRoute";      // ← NEW import
+import ErrorBoundary  from "./components/ErrorBoundary";
 
 // Route-level code splitting: each page (and its exclusive dependencies, e.g. three.js
 // for VectorGraphPage) only downloads when a visitor actually navigates to it.
@@ -60,6 +61,7 @@ const App: React.FC = () => (
       <Navbar />
 
       <div className="main-content">
+        <ErrorBoundary>
         <Suspense fallback={<div className="page-loading" role="status">Loading…</div>}>
         <Routes>
           {/* public site */}
@@ -118,6 +120,7 @@ const App: React.FC = () => (
           </Route>
         </Routes>
         </Suspense>
+        </ErrorBoundary>
       </div>
 
       <Footer />

--- a/FE/src/components/ErrorBoundary.tsx
+++ b/FE/src/components/ErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error("Unhandled UI error:", error, info.componentStack);
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="page-loading" role="alert">
+          <p>Something went wrong loading this page.</p>
+          <button type="button" onClick={this.handleRetry}>
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
﻿## Summary
- Add ErrorBoundary component with Try again fallback.
- Wrap Suspense routes in App so render errors stay contained.

## Test plan
- [ ] Normal navigation still works
- [ ] Force a throw in a page — see alert + Try again, header/nav remain
