### PR TITLE
seo(fe): add Schedules page meta tags

### DIFF
--- a/FE/src/components/Schedules.tsx
+++ b/FE/src/components/Schedules.tsx
@@ -8,6 +8,7 @@ import FilterBar from './ui/FilterBar';
 import { formatGameStage } from '../utils/gameLabels';
 import { isSafeExternalUrl } from '../utils/url';
 import { useRegion } from '../context/regionContext';
+import SEO from './SEO';
 import '../styles/Schedules.css';
 
 const Schedules: React.FC = () => {
@@ -191,6 +192,11 @@ const Schedules: React.FC = () => {
 
   return (
     <>
+      <SEO
+        title="Schedules"
+        description="Upcoming Roblox Volleyball League match schedules, dates, and stages."
+        url="https://volleyball4-2.com/schedules"
+      />
       <div className="schedules-page">
         {/* VNL-Style Header */}
         <div className="vnl-header">


### PR DESCRIPTION
﻿## Summary
- Add SEO component to Schedules with title, description, and URL.

## Test plan
- [ ] /schedules document title includes Schedules
