### PR TITLE
refactor(be): type Request.user as VerifiedJwtUser

### DIFF
--- a/BE/globals.d.ts
+++ b/BE/globals.d.ts
@@ -1,9 +1,11 @@
-import { JwtPayload } from "jsonwebtoken";
+import type { VerifiedJwtUser } from "./src/middleware/authValidation.js";
 
 declare global {
   namespace Express {
     interface Request {
-      user?: JwtPayload & { id?: number, username?: string, role?: string }
+      user?: VerifiedJwtUser;
     }
   }
 }
+
+export {};

--- a/BE/src/middleware/authentication.ts
+++ b/BE/src/middleware/authentication.ts
@@ -26,7 +26,7 @@ export const authenticateToken = (req: Request, res: Response, next: NextFunctio
                 throw new UnauthorizedError("Invalid or expired token");
             }
 
-            (req as any).user = await validateJwtPayload(decoded as jwt.JwtPayload);
+            req.user = await validateJwtPayload(decoded as jwt.JwtPayload);
             next();
         }
         catch (err)


### PR DESCRIPTION
﻿## Summary
- Set Request.user to VerifiedJwtUser in globals.d.ts.
- Assign req.user directly in authenticateToken without any cast.

## Test plan
- [ ] Login and authenticated admin routes still work
- [ ] Typecheck: req.user.id/role are typed
