### PR TITLE
fix(be): import missing triviaRateLimiter

### DIFF
--- a/BE/src/modules/trivia/trivia.routes.ts
+++ b/BE/src/modules/trivia/trivia.routes.ts
@@ -1,5 +1,6 @@
 import { Application, Router } from 'express';
 import { TriviaController } from './trivia.controller.js';
+import { triviaRateLimiter } from '../../middleware/rateLimit.js';
 
 /**
  * Register trivia routes with the Express application


### PR DESCRIPTION
﻿## Summary
- Add the missing `triviaRateLimiter` import in `trivia.routes.ts`.

## Why
Main currently calls `router.use(triviaRateLimiter)` without importing it (merge regression), so the BE fails TypeScript and would throw at runtime when registering routes.

## Test plan
- [ ] cd BE && npx tsc --noEmit
- [ ] Server starts and /api/trivia routes load
