### PR TITLE
Fix FE cookie auth for likes and mutation hooks

### DIFF
--- a/FE/src/hooks/allCreate.ts
+++ b/FE/src/hooks/allCreate.ts
@@ -120,13 +120,13 @@ export const useCreateAwards = () => {
 export const useCSVUpload = (showErrorModal?: (err: any) => void) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const { token } = useAuth();
+  const { token, isAuthenticated } = useAuth();
 
   const uploadCSV = async (payload: CSVUploadPayload): Promise<CSVUploadResult | null> => {
     setLoading(true);
     setError(null);
 
-    if (!token) {
+    if (!isAuthenticated) {
       const errorMsg = "You must be logged in to upload CSV files";
       setError(errorMsg);
       if (showErrorModal) showErrorModal({ message: errorMsg });
@@ -188,13 +188,13 @@ export const useCSVUpload = (showErrorModal?: (err: any) => void) => {
 export const useAddStatsToExistingGame = (showErrorModal?: (err: any) => void) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const { token } = useAuth();
+  const { token, isAuthenticated } = useAuth();
 
   const addStatsToGame = async (gameId: number, statsData: any[]): Promise<Stats[] | null> => {
     setLoading(true);
     setError(null);
 
-    if (!token) {
+    if (!isAuthenticated) {
       const errorMsg = "You must be logged in to add stats to games";
       setError(errorMsg);
       if (showErrorModal) showErrorModal({ message: errorMsg });
@@ -256,13 +256,13 @@ export const useAddStatsToExistingGame = (showErrorModal?: (err: any) => void) =
 export const useCalculateRecords = (showErrorModal?: (err: any) => void) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const { token } = useAuth();
+  const { token, isAuthenticated } = useAuth();
 
   const calculateRecords = async (): Promise<boolean> => {
     setLoading(true);
     setError(null);
 
-    if (!token) {
+    if (!isAuthenticated) {
       const errorMsg = "You must be logged in to calculate records";
       setError(errorMsg);
       if (showErrorModal) showErrorModal({ message: errorMsg });

--- a/FE/src/hooks/allPatch.ts
+++ b/FE/src/hooks/allPatch.ts
@@ -72,14 +72,14 @@ export function useAwardsMutations() {
 }
 
 export function useApplicationMutations() {
-  const { token } = useAuth();
+  const { token, isAuthenticated } = useAuth();
 
   const patchApplication = useCallback(
     async (
       slug: string,
       data: Pick<Application, "url" | "status">
     ): Promise<Application> => {
-      if (!token) {
+      if (!isAuthenticated) {
         throw new Error("You must be logged in to update applications");
       }
 
@@ -100,7 +100,7 @@ export function useApplicationMutations() {
 
       return res.json() as Promise<Application>;
     },
-    [token]
+    [token, isAuthenticated]
   );
 
   return { patchApplication };

--- a/FE/src/hooks/useCreate.ts
+++ b/FE/src/hooks/useCreate.ts
@@ -17,13 +17,13 @@ import { useAuth } from "../context/authContext";
 export const useCreate = <T, U>(endpoint: string) => {
     const [loading, setLoading] = useState<boolean>(false);
     const [error, setError]     = useState<string | null>(null);
-    const { token } = useAuth();
+    const { token, isAuthenticated } = useAuth();
 
     async function createItem(payload: U): Promise<T | null> {
         setLoading(true);
         setError(null);
 
-        if (!token) {
+        if (!isAuthenticated) {
             setError("You must be logged in to create items");
             return null;
         }

--- a/FE/src/hooks/useCreatePlayers.ts
+++ b/FE/src/hooks/useCreatePlayers.ts
@@ -37,7 +37,7 @@ export type BatchPlayerByNameInput = {
 export function useBatchPlayersByTeamName() {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError]     = useState<string | null>(null);
-  const { token } = useAuth();
+  const { token, isAuthenticated } = useAuth();
 
   async function createBatch(
     payload: BatchPlayerByNameInput
@@ -45,7 +45,7 @@ export function useBatchPlayersByTeamName() {
     setLoading(true);
     setError(null);
 
-    if (!token) {
+    if (!isAuthenticated) {
       setError("You must be logged in to create players");
       return null;
     }

--- a/FE/src/hooks/useDelete.ts
+++ b/FE/src/hooks/useDelete.ts
@@ -11,7 +11,7 @@ import { useAuth } from "../context/authContext";
 export const useDelete = (endpoint: string) => {
     const [loading, setLoading] = useState<boolean>(false);
     const [error, setError]     = useState<string | null>(null);
-    const { token } = useAuth();
+    const { token, isAuthenticated } = useAuth();
 
     /**
      * Sends a DELETE to `/api/${endpoint}/${id}`.
@@ -22,7 +22,7 @@ export const useDelete = (endpoint: string) => {
         setLoading(true);
         setError(null);
 
-        if (!token) {
+        if (!isAuthenticated) {
             setError("You must be logged in to delete items");
             return null;
         }

--- a/FE/src/hooks/useLikeArticle.ts
+++ b/FE/src/hooks/useLikeArticle.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import axios from 'axios';
 import { useAuth } from '../context/authContext';
+import { authFetch } from './authFetch';
 
 interface UseLikeArticleReturn {
   likeArticle: (articleId: number) => Promise<boolean>;
@@ -10,48 +10,44 @@ interface UseLikeArticleReturn {
   error: string | null;
 }
 
+const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
+
 export function useLikeArticle(): UseLikeArticleReturn {
   const [isLiking, setIsLiking] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { token } = useAuth();
+  const { token, isAuthenticated } = useAuth();
 
   const likeArticle = async (articleId: number): Promise<boolean> => {
     setIsLiking(true);
     setError(null);
 
     try {
-      if (!token) {
+      if (!isAuthenticated) {
         setError('You must be logged in to like articles');
         return false;
       }
 
-      await axios.post(
-        `${import.meta.env.VITE_BACKEND_URL}/api/articles/${articleId}/like`,
-        {},
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json'
-          }
-        }
+      const response = await authFetch(
+        `${backendUrl}/api/articles/${articleId}/like`,
+        { method: 'POST', body: JSON.stringify({}) },
+        token
       );
-      
-      return true;
-    } catch (err: any) {
-      let errorMessage = 'Failed to like article';
-      
-      if (err.response) {
-        if (err.response.status === 409) {
-          errorMessage = 'You have already liked this article';
-        } else if (err.response.status === 401) {
-          errorMessage = 'You must be logged in to like articles';
-        } else if (err.response.data?.message) {
-          errorMessage = err.response.data.message;
+
+      if (!response.ok) {
+        if (response.status === 409) {
+          setError('You have already liked this article');
+        } else if (response.status === 401) {
+          setError('You must be logged in to like articles');
+        } else {
+          const data = await response.json().catch(() => ({}));
+          setError(data.message || 'Failed to like article');
         }
-      } else if (err.message) {
-        errorMessage = err.message;
+        return false;
       }
-      
+
+      return true;
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to like article';
       setError(errorMessage);
       console.error('Error liking article:', err);
       return false;
@@ -65,37 +61,32 @@ export function useLikeArticle(): UseLikeArticleReturn {
     setError(null);
 
     try {
-      if (!token) {
+      if (!isAuthenticated) {
         setError('You must be logged in to unlike articles');
         return false;
       }
 
-      await axios.delete(
-        `${import.meta.env.VITE_BACKEND_URL}/api/articles/${articleId}/like`,
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json'
-          }
-        }
+      const response = await authFetch(
+        `${backendUrl}/api/articles/${articleId}/like`,
+        { method: 'DELETE' },
+        token
       );
-      
-      return true;
-    } catch (err: any) {
-      let errorMessage = 'Failed to unlike article';
-      
-      if (err.response) {
-        if (err.response.status === 409) {
-          errorMessage = 'You have not liked this article';
-        } else if (err.response.status === 401) {
-          errorMessage = 'You must be logged in to unlike articles';
-        } else if (err.response.data?.message) {
-          errorMessage = err.response.data.message;
+
+      if (!response.ok) {
+        if (response.status === 409) {
+          setError('You have not liked this article');
+        } else if (response.status === 401) {
+          setError('You must be logged in to unlike articles');
+        } else {
+          const data = await response.json().catch(() => ({}));
+          setError(data.message || 'Failed to unlike article');
         }
-      } else if (err.message) {
-        errorMessage = err.message;
+        return false;
       }
-      
+
+      return true;
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to unlike article';
       setError(errorMessage);
       console.error('Error unliking article:', err);
       return false;

--- a/FE/src/hooks/useLikeStatus.ts
+++ b/FE/src/hooks/useLikeStatus.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
 import { useAuth } from '../context/authContext';
+import { authFetch } from './authFetch';
 
 interface UseLikeStatusReturn {
   hasLiked: boolean;
@@ -9,35 +9,38 @@ interface UseLikeStatusReturn {
   refetch: () => void;
 }
 
+const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
+
 export function useLikeStatus(articleId: number): UseLikeStatusReturn {
   const [hasLiked, setHasLiked] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const { token } = useAuth();
+  const { token, isAuthenticated } = useAuth();
 
   const fetchLikeStatus = async () => {
     setLoading(true);
     setError(null);
 
     try {
-      if (!token) {
+      if (!isAuthenticated) {
         setHasLiked(false);
         setLoading(false);
         return;
       }
 
-      const response = await axios.get(
-        `${import.meta.env.VITE_BACKEND_URL}/api/articles/${articleId}/like-status`,
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json'
-          }
-        }
+      const response = await authFetch(
+        `${backendUrl}/api/articles/${articleId}/like-status`,
+        { method: 'GET' },
+        token
       );
-      
-      setHasLiked((response.data as { hasLiked: boolean }).hasLiked);
-    } catch (err: any) {
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch like status');
+      }
+
+      const data = await response.json() as { hasLiked: boolean };
+      setHasLiked(data.hasLiked);
+    } catch (err: unknown) {
       console.error('Error fetching like status:', err);
       setError('Failed to fetch like status');
       setHasLiked(false);
@@ -48,7 +51,7 @@ export function useLikeStatus(articleId: number): UseLikeStatusReturn {
 
   useEffect(() => {
     fetchLikeStatus();
-  }, [articleId, token]);
+  }, [articleId, isAuthenticated]);
 
   const refetch = () => {
     fetchLikeStatus();
@@ -60,4 +63,4 @@ export function useLikeStatus(articleId: number): UseLikeStatusReturn {
     error,
     refetch
   };
-} 
+}

--- a/FE/src/hooks/usePatch.ts
+++ b/FE/src/hooks/usePatch.ts
@@ -8,12 +8,12 @@ const backendUrl =
 
 export function usePatch<T = any>(resource: string)
 {
-    const { token } = useAuth();
+    const { token, isAuthenticated } = useAuth();
     
     const patch = useCallback(
         async (id: number, data: Partial<T>): Promise<T> =>
         {
-            if (!token) {
+            if (!isAuthenticated) {
                 throw new Error("You must be logged in to update items");
             }
 
@@ -48,7 +48,7 @@ export function usePatch<T = any>(resource: string)
             const json = await res.json();
             return json as T;
         },
-        [resource]
+        [resource, token, isAuthenticated]
     );
 
     return { patch };


### PR DESCRIPTION
## Summary
- Migrate article like/unlike/like-status from axios Bearer tokens to cookie-aware `authFetch`
- Gate mutation hooks on `isAuthenticated` instead of `token` (always null after cookie auth)

## Test plan
- [ ] Log in (cookie session), like and unlike an article
- [ ] Confirm like status loads for logged-in users and stays false when logged out
- [ ] Portal create/patch/delete still works while logged in
- [ ] MSW mock mode still works with bearer token

Made with [Cursor](https://cursor.com)