### PR TITLE
Stop tracking FE/.env and add FE .gitignore

### DIFF
--- a/FE/.env
+++ b/FE/.env
@@ -1,5 +1,0 @@
-REACT_APP_API_URL=https://api.volleyball4-2.com
-VITE_API_URL=https://api.volleyball4-2.com
-
-FRONTEND_URL=http://localhost:5173
-

--- a/FE/.gitignore
+++ b/FE/.gitignore
@@ -1,0 +1,5 @@
+# Local env (do not commit)
+.env
+.env.local
+.env.*.local
+


### PR DESCRIPTION
## Summary
- Remove tracked `FE/.env` (wrong `VITE_API_URL` / `REACT_APP_API_URL` names)
- Add `FE/.gitignore` so local `.env` files stay untracked
- Keep `FE/.env.example` as the documented contract (`VITE_BACKEND_URL`)

## Test plan
- [ ] Confirm `FE/.env` is no longer in the tree after checkout
- [ ] Copy `.env.example` to `.env` and run FE against local BE

Made with [Cursor](https://cursor.com)