### PR TITLE
Point TypeORM AppDataSource at src/migrations

### DIFF
--- a/BE/src/db/data-source.ts
+++ b/BE/src/db/data-source.ts
@@ -57,7 +57,7 @@ export const AppDataSource = new DataSource({
     logging: process.env.NODE_ENV === "production" ? ["error"] : ["error", "warn", "migration"],
     maxQueryExecutionTime: 1000,
     entities: entities,
-    migrations: [join(__dirname, "..", "..", "migrations", "*.{js,ts}")], // Point to dist/migrations in production
+    migrations: [join(__dirname, "..", "migrations", "*.{js,ts}")], // src/migrations (or dist/migrations after build)
     migrationsTableName: "migrations", // Explicitly set migrations table name
     migrationsTransactionMode: "each",
     subscribers: [],


### PR DESCRIPTION
## Summary
- Fix `AppDataSource` migrations glob from empty `BE/migrations` to `src/migrations` (`dist/migrations` after `tsc`)
- Aligns CLI/data-source path with the production `run-migrations.ts` location

## Test plan
- [ ] `typeorm migration:show` (or equivalent) lists migrations from `src/migrations`
- [ ] Prod `start.sh` / `run-migrations.ts` path unchanged and still works

Made with [Cursor](https://cursor.com)