### PR TITLE
Allow any authenticated user to submit articles

### DIFF
--- a/BE/src/modules/articles/article.controller.ts
+++ b/BE/src/modules/articles/article.controller.ts
@@ -18,9 +18,15 @@ export class ArticleController {
      * Create a new article
      */
     public createArticle = async (req: Request, res: Response): Promise<void> => {
-        const { title, content, userId, summary, imageUrl } = req.body;
+        const { title, content, summary, imageUrl } = req.body;
+        const userId = req.user?.id;
 
         try {
+            if (!userId) {
+                res.status(401).json({ message: 'Authentication required' });
+                return;
+            }
+
             const newArticle = await this.articleService.createArticle(
                 title,
                 content,

--- a/BE/src/modules/articles/article.routes.ts
+++ b/BE/src/modules/articles/article.routes.ts
@@ -10,8 +10,8 @@ export function registerArticleRoutes(app: Application): void
     const router = Router();
     const articleController = new ArticleController();
 
-    // Create a new article - PROTECTED
-    router.post('/', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(createArticleSchema), articleController.createArticle);
+    // Create a new article - any authenticated user; starts as pending approval
+    router.post('/', authenticateCombined, validate(createArticleSchema), articleController.createArticle);
 
     // GET routes - PUBLIC (for website display)
     router.get('/', articleController.getAllArticles);

--- a/BE/src/modules/articles/article.schema.ts
+++ b/BE/src/modules/articles/article.schema.ts
@@ -4,7 +4,8 @@ export const createArticleSchema = z.object({
     title: z.string().min(1, { message: "Title is required" }),
     content: z.string().min(240, { message: "Content is required, min 240 characters" }),
     imageUrl: z.string().url({ message: "Image URL is required and must be a valid URL" }),
-    userId: z.number().int().positive(),  // Changed from authorId to userId
+    // Author comes from the authenticated user; body userId is ignored if present
+    userId: z.number().int().positive().optional(),
     summary: z.string().min(50, { message: "Summary is required, min 50 characters" }),
     likes: z.number().int().positive().default(0).optional(),
     approved: z.boolean().nullable().optional(),


### PR DESCRIPTION
## Summary
- Drop admin-only gate on `POST /api/articles` so logged-in users can submit
- Set author from `req.user.id` (ignore body `userId`) to prevent spoofing
- Service still creates articles with `approved: null` (pending)

## Test plan
- [ ] Logged-in `user` role can create an article; it is pending
- [ ] Unauthenticated create returns 401
- [ ] Admin update/approve/delete paths unchanged
- [ ] FE `/articles/create` succeeds for a normal user

Made with [Cursor](https://cursor.com)