### PR TITLE
Add CI workflow for backend and frontend builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: BE
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: BE/package-lock.json
+      - run: npm ci
+      - run: npm run build
+        env:
+          NODE_ENV: production
+
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: FE
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: FE/package-lock.json
+      - run: npm ci
+      - run: npm run build
+        env:
+          VITE_BACKEND_URL: http://localhost:3000


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI that runs `npm ci` + `npm run build` for `BE` and `FE` on pushes/PRs to `main`
- Intentionally skips `npm test` / `npm run lint` for now — BE Jest currently has failing suites and FE lint has 100+ existing errors

## Test plan
- [ ] CI runs green on this PR
- [ ] A follow-up can enable tests/lint once those are cleaned up

Made with [Cursor](https://cursor.com)