### PR TITLE
Disable synchronize and add performance indexes

### DIFF
--- a/BE/src/db/data-source.ts
+++ b/BE/src/db/data-source.ts
@@ -53,7 +53,9 @@ export const AppDataSource = new DataSource({
             database: process.env.DB_NAME || "volleyball",
         }
     ),
-    synchronize: process.env.NODE_ENV === "development",
+    // Never auto-sync from NODE_ENV — opt in explicitly for throwaway local DBs only.
+    // Schema changes ship via migrations (see src/migrations).
+    synchronize: process.env.TYPEORM_SYNCHRONIZE === "true",
     logging: process.env.NODE_ENV === "production" ? ["error"] : ["error", "warn", "migration"],
     maxQueryExecutionTime: 1000,
     entities: entities,

--- a/BE/src/migrations/1712345678923-AddPerformanceIndexes.ts
+++ b/BE/src/migrations/1712345678923-AddPerformanceIndexes.ts
@@ -1,24 +1,43 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
+/**
+ * Indexes for FK joins and the hot filter/sort paths used by list, leaderboard,
+ * and record-calculation queries. IF NOT EXISTS keeps this safe to re-run.
+ */
 export class AddPerformanceIndexes1712345678923 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        // games: filtered/sorted by region+season constantly, plus individual status/phase/bracket filters
+        // games: filtered/sorted by region+season constantly, plus stage/status/phase/bracket
         await queryRunner.query(`
             CREATE INDEX IF NOT EXISTS "IDX_games_regionId_seasonId_date"
             ON "games" ("regionId", "seasonId", "date")
         `);
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS "IDX_games_seasonId_regionId_stage"
+            ON "games" ("seasonId", "regionId", "stage")
+        `);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_games_seasonId" ON "games" ("seasonId")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_games_stage" ON "games" ("stage")`);
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_games_status" ON "games" ("status")`);
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_games_phase" ON "games" ("phase")`);
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_games_bracket" ON "games" ("bracket")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_games_winnerTeamId" ON "games" ("winnerTeamId")`);
 
         // stats: joined to player/game on every stats and leaderboard query
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_stats_playerId" ON "stats" ("playerId")`);
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_stats_gameId" ON "stats" ("gameId")`);
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS "IDX_stats_gameId_playerId"
+            ON "stats" ("gameId", "playerId")
+        `);
 
-        // records: filtered by season/player/region, and record+type is the calculateAllRecords delete key
+        // players: equality + ILIKE name lookups on list/search/trivia
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_players_name" ON "players" ("name")`);
+
+        // records: filtered by season/player/region/game; record+type is the calculateAllRecords delete key
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_records_seasonId" ON "records" ("seasonId")`);
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_records_playerId" ON "records" ("playerId")`);
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_records_regionId" ON "records" ("regionId")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_records_gameId" ON "records" ("gameId")`);
         await queryRunner.query(`
             CREATE INDEX IF NOT EXISTS "IDX_records_record_type"
             ON "records" ("record", "type")
@@ -27,26 +46,51 @@ export class AddPerformanceIndexes1712345678923 implements MigrationInterface {
         // teams: filtered by region and season on every list/detail query
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_teams_regionId" ON "teams" ("regionId")`);
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_teams_seasonId" ON "teams" ("seasonId")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_teams_name" ON "teams" ("name")`);
+
+        // seasons: filtered by region
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_seasons_regionId" ON "seasons" ("regionId")`);
 
         // awards: filtered by season and region
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_awards_seasonId" ON "awards" ("seasonId")`);
         await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_awards_regionId" ON "awards" ("regionId")`);
+
+        // article: approval filter on public listing
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_article_approved" ON "article" ("approved")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_article_authorId" ON "article" ("authorId")`);
+
+        // role audit: lookup by target/actor
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_role_audit_log_targetId" ON "role_audit_log" ("targetId")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_role_audit_log_actorId" ON "role_audit_log" ("actorId")`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_role_audit_log_actorId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_role_audit_log_targetId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_article_authorId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_article_approved"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_awards_regionId"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_awards_seasonId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_seasons_regionId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_teams_name"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_teams_seasonId"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_teams_regionId"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_records_record_type"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_records_gameId"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_records_regionId"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_records_playerId"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_records_seasonId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_players_name"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_stats_gameId_playerId"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_stats_gameId"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_stats_playerId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_winnerTeamId"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_bracket"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_phase"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_status"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_stage"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_seasonId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_seasonId_regionId_stage"`);
         await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_regionId_seasonId_date"`);
     }
 }

--- a/BE/src/migrations/1712345678924-AddRemainingPerformanceIndexes.ts
+++ b/BE/src/migrations/1712345678924-AddRemainingPerformanceIndexes.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Indexes added after the initial performance set (8923).
+ * Safe if 8923 was already expanded to include these — all use IF NOT EXISTS.
+ */
+export class AddRemainingPerformanceIndexes1712345678924 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS "IDX_games_seasonId_regionId_stage"
+            ON "games" ("seasonId", "regionId", "stage")
+        `);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_games_seasonId" ON "games" ("seasonId")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_games_stage" ON "games" ("stage")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_games_winnerTeamId" ON "games" ("winnerTeamId")`);
+
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS "IDX_stats_gameId_playerId"
+            ON "stats" ("gameId", "playerId")
+        `);
+
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_players_name" ON "players" ("name")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_records_gameId" ON "records" ("gameId")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_teams_name" ON "teams" ("name")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_seasons_regionId" ON "seasons" ("regionId")`);
+
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_article_approved" ON "article" ("approved")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_article_authorId" ON "article" ("authorId")`);
+
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_role_audit_log_targetId" ON "role_audit_log" ("targetId")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_role_audit_log_actorId" ON "role_audit_log" ("actorId")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_role_audit_log_actorId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_role_audit_log_targetId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_article_authorId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_article_approved"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_seasons_regionId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_teams_name"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_records_gameId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_players_name"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_stats_gameId_playerId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_winnerTeamId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_stage"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_seasonId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_games_seasonId_regionId_stage"`);
+    }
+}

--- a/BE/src/modules/articles/article.entity.ts
+++ b/BE/src/modules/articles/article.entity.ts
@@ -1,7 +1,9 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, ManyToMany, JoinTable } from "typeorm";
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, ManyToMany, JoinTable, Index } from "typeorm";
 import { User } from "../user/user.entity.js";
 
 @Entity()
+@Index("IDX_article_approved", ["approved"])
+@Index("IDX_article_authorId", ["author"])
 export class Article
 {
     @PrimaryGeneratedColumn()

--- a/BE/src/modules/awards/award.entity.ts
+++ b/BE/src/modules/awards/award.entity.ts
@@ -1,9 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToMany, JoinTable, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToMany, JoinTable, ManyToOne, JoinColumn, Index } from 'typeorm';
 import { Players } from '../players/player.entity.js';
 import { Seasons } from '../seasons/season.entity.js';
 import type { Region } from '../regions/region.entity.js';
 
 @Entity()
+@Index('IDX_awards_seasonId', ['seasonId'])
+@Index('IDX_awards_regionId', ['regionId'])
 export class Awards {
     @PrimaryGeneratedColumn()
     id!: number;

--- a/BE/src/modules/games/game.entity.ts
+++ b/BE/src/modules/games/game.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, ManyToMany, JoinTable, OneToMany, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, ManyToMany, JoinTable, OneToMany, JoinColumn, Index } from 'typeorm';
 import type { Seasons } from '../seasons/season.entity.js';
 import type { Teams } from '../teams/team.entity.js';
 import type { Stats } from '../stats/stat.entity.js';
@@ -22,6 +22,14 @@ export enum GameBracket {
 }
 
 @Entity()
+@Index('IDX_games_regionId_seasonId_date', ['regionId', 'season', 'date'])
+@Index('IDX_games_seasonId_regionId_stage', ['season', 'regionId', 'stage'])
+@Index('IDX_games_seasonId', ['season'])
+@Index('IDX_games_stage', ['stage'])
+@Index('IDX_games_status', ['status'])
+@Index('IDX_games_phase', ['phase'])
+@Index('IDX_games_bracket', ['bracket'])
+@Index('IDX_games_winnerTeamId', ['winnerTeamId'])
 export class Games {
     @PrimaryGeneratedColumn()
     id!: number;

--- a/BE/src/modules/players/player.entity.ts
+++ b/BE/src/modules/players/player.entity.ts
@@ -1,10 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, OneToMany, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany, ManyToMany, JoinTable, Index } from 'typeorm';
 import type { Teams } from '../teams/team.entity.js';
 import type { Stats } from '../stats/stat.entity.js';
 import type { Awards } from '../awards/award.entity.js';
 import type { Records } from '../records/records.entity.js';
 
 @Entity()
+@Index('IDX_players_name', ['name'])
 export class Players {
     @PrimaryGeneratedColumn()
     id!: number;

--- a/BE/src/modules/records/records.entity.ts
+++ b/BE/src/modules/records/records.entity.ts
@@ -1,9 +1,14 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn, Index } from 'typeorm';
 import type { Seasons } from '../seasons/season.entity.js';
 import type { Players } from '../players/player.entity.js';
 import type { Region } from '../regions/region.entity.js';
 
 @Entity()
+@Index('IDX_records_seasonId', ['seasonId'])
+@Index('IDX_records_playerId', ['playerId'])
+@Index('IDX_records_regionId', ['regionId'])
+@Index('IDX_records_gameId', ['gameId'])
+@Index('IDX_records_record_type', ['record', 'type'])
 export class Records {
     @PrimaryGeneratedColumn()
     id!: number;

--- a/BE/src/modules/seasons/season.entity.ts
+++ b/BE/src/modules/seasons/season.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany, ManyToOne, JoinColumn, Index } from 'typeorm';
 import type { Games } from '../games/game.entity.js';
 import type { Teams } from '../teams/team.entity.js';
 import type { Awards } from '../awards/award.entity.js';
@@ -6,6 +6,7 @@ import type { Records } from '../records/records.entity.js';
 import type { Region } from '../regions/region.entity.js';
 
 @Entity()
+@Index('IDX_seasons_regionId', ['regionId'])
 export class Seasons {
     @PrimaryGeneratedColumn()
     id!: number;

--- a/BE/src/modules/stats/stat.entity.ts
+++ b/BE/src/modules/stats/stat.entity.ts
@@ -1,8 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, RelationId } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, RelationId, Index } from 'typeorm';
 import type { Players } from '../players/player.entity.js';
 import type { Games } from '../games/game.entity.js';
 
 @Entity()
+@Index('IDX_stats_playerId', ['player'])
+@Index('IDX_stats_gameId', ['game'])
+@Index('IDX_stats_gameId_playerId', ['game', 'player'])
 export class Stats {
     @PrimaryGeneratedColumn()
     id!: number;

--- a/BE/src/modules/teams/team.entity.ts
+++ b/BE/src/modules/teams/team.entity.ts
@@ -1,10 +1,13 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, OneToMany, ManyToMany, JoinTable, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, ManyToMany, JoinTable, JoinColumn, Index } from 'typeorm';
 import type { Seasons } from '../seasons/season.entity.js';
 import type { Players } from '../players/player.entity.js';
 import type { Games } from '../games/game.entity.js';
 import type { Region } from '../regions/region.entity.js';
 
 @Entity()
+@Index('IDX_teams_regionId', ['regionId'])
+@Index('IDX_teams_seasonId', ['season'])
+@Index('IDX_teams_name', ['name'])
 export class Teams 
 {
     @PrimaryGeneratedColumn()

--- a/BE/src/modules/user/role-audit-log.entity.ts
+++ b/BE/src/modules/user/role-audit-log.entity.ts
@@ -2,10 +2,13 @@ import {
     Column,
     CreateDateColumn,
     Entity,
+    Index,
     PrimaryGeneratedColumn,
 } from "typeorm";
 
-@Entity()
+@Entity("role_audit_log")
+@Index("IDX_role_audit_log_targetId", ["targetId"])
+@Index("IDX_role_audit_log_actorId", ["actorId"])
 export class RoleAuditLog {
     @PrimaryGeneratedColumn()
     id!: number;


### PR DESCRIPTION
## Summary
- Gate `synchronize` behind explicit `TYPEORM_SYNCHRONIZE=true` instead of `NODE_ENV === development`
- Expand/add performance index migrations for games, stats, players, records, teams, seasons, awards, articles, and role audit logs
- Mirror those indexes with `@Index` on entities; pin `RoleAuditLog` table name to `role_audit_log`

## Test plan
- [ ] Fresh local DB: run migrations, confirm indexes exist
- [ ] Boot BE without `TYPEORM_SYNCHRONIZE` and confirm schema is not auto-altered
- [ ] Boot with `TYPEORM_SYNCHRONIZE=true` only on a throwaway DB if needed
- [ ] Smoke list/filter endpoints for games, players, stats, records