### PR TITLE
Validate PUT update routes with Zod

### DIFF
--- a/BE/src/modules/articles/article.routes.ts
+++ b/BE/src/modules/articles/article.routes.ts
@@ -19,7 +19,7 @@ export function registerArticleRoutes(app: Application): void
     router.get('/:id', articleController.getArticleById);
 
     // UPDATE/DELETE routes - PROTECTED
-    router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), articleController.updateArticle);
+    router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updateArticleSchema), articleController.updateArticle);
     router.patch('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updateArticleSchema), articleController.updateArticle);
     router.delete('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), articleController.deleteArticle);
 

--- a/BE/src/modules/games/game.routes.ts
+++ b/BE/src/modules/games/game.routes.ts
@@ -29,7 +29,7 @@ export function registerGameRoutes(app: Application): void {
     router.post('/createByNames', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(createGameByNamesSchema), gameController.createGameByNames);
 
     // UPDATE/DELETE routes - PROTECTED
-    router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), gameController.updateGame); // Update a game (update score if needed)
+    router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updateGameSchema), gameController.updateGame); // Update a game (update score if needed)
     router.patch('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updateGameSchema), gameController.updateGame); // Only update given fields
     router.delete('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), gameController.deleteGame); // Delete a game
 

--- a/BE/src/modules/players/player.routes.ts
+++ b/BE/src/modules/players/player.routes.ts
@@ -32,7 +32,7 @@ export function registerPlayerRoutes(app: Application): void
     router.get('/:id', cacheMiddleware({ prefix: 'players', ttl: 600 }), playerController.getPlayerById);
 
     // UPDATE/DELETE routes - PROTECTED - with cache invalidation
-    router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), invalidateCacheMiddleware('players'), playerController.updatePlayer);
+    router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updatePlayerSchema), invalidateCacheMiddleware('players'), playerController.updatePlayer);
     router.patch('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updatePlayerSchema), invalidateCacheMiddleware('players'), playerController.updatePlayer);
     router.delete('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), invalidateCacheMiddleware('players'), playerController.deletePlayer);
     router.get('/team/:teamId', cacheMiddleware({ prefix: 'players', ttl: 600 }), playerController.getPlayersByTeamId);

--- a/BE/src/modules/records/records.routes.ts
+++ b/BE/src/modules/records/records.routes.ts
@@ -24,7 +24,7 @@ export function registerRecordRoutes(app: Application): void {
     router.get('/:id', recordController.getRecordById);
     
     // UPDATE/DELETE routes - PROTECTED
-    router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), recordController.updateRecord);
+    router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updateRecordSchema), recordController.updateRecord);
     router.patch('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updateRecordSchema), recordController.updateRecord);
     router.delete('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), recordController.deleteRecord);
 

--- a/BE/src/modules/seasons/season.routes.ts
+++ b/BE/src/modules/seasons/season.routes.ts
@@ -19,7 +19,7 @@ export function registerSeasonRoutes(app: Application): void {
     router.get('/:id', seasonController.getSeasonById);
     
     // UPDATE/DELETE routes - PROTECTED
-    router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), seasonController.updateSeason);
+    router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updateSeasonSchema), seasonController.updateSeason);
     router.patch('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updateSeasonSchema), seasonController.updateSeason);
     router.delete('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), seasonController.deleteSeason);
 


### PR DESCRIPTION
## Summary
- Add validate(updateXSchema) to PUT /:id on games, players, seasons, articles, and records
- Aligns PUT with PATCH (teams/stats already validated both)

## Test plan
- [ ] PUT with valid body succeeds for each module
- [ ] PUT with invalid/malformed body returns 400
- [ ] PATCH behavior unchanged