### PR TITLE
fix: wrap multi-step batch writes in transactions (audit H3)

### DIFF
--- a/BE/src/modules/awards/award.service.ts
+++ b/BE/src/modules/awards/award.service.ts
@@ -1,4 +1,4 @@
-import { Repository, In } from 'typeorm';
+import { Repository, In, EntityManager } from 'typeorm';
 import { AppDataSource } from '../../db/data-source.js';
 import { Awards } from './award.entity.js';
 import { Seasons } from '../seasons/season.entity.js';
@@ -45,17 +45,21 @@ export class AwardService {
      * @throws {NotFoundError} If the season is not found
      * @throws {DuplicateError} If an award of the same type already exists in the season
      */
-    async createAward(awardData: CreateAwardDto): Promise<Awards> {
+    async createAward(awardData: CreateAwardDto, manager?: EntityManager): Promise<Awards> {
+        const awardRepository = manager ? manager.getRepository(Awards) : this.awardRepository;
+        const seasonRepository = manager ? manager.getRepository(Seasons) : this.seasonRepository;
+        const playerRepository = manager ? manager.getRepository(Players) : this.playerRepository;
+
         const { description, type, imageUrl, seasonId, playerIds } = awardData;
 
         // Check if season exists
-        const season = await this.seasonRepository.findOne({ where: { id: seasonId } });
+        const season = await seasonRepository.findOne({ where: { id: seasonId } });
         if (!season) {
             throw new NotFoundError(`Season with ID ${seasonId} not found`);
         }
 
         // Check if award of same type exists in the season
-        const existingTypeAward = await this.awardRepository.findOne({
+        const existingTypeAward = await awardRepository.findOne({
             where: { type, season: { id: seasonId } }
         });
         if (existingTypeAward) {
@@ -63,7 +67,7 @@ export class AwardService {
         }
 
         // Create new award
-        const award = this.awardRepository.create({
+        const award = awardRepository.create({
             description,
             type,
             imageUrl,
@@ -73,7 +77,7 @@ export class AwardService {
 
         // Add players if provided
         if (playerIds && playerIds.length > 0) {
-            const players = await this.playerRepository.findBy({ id: In(playerIds) });
+            const players = await playerRepository.findBy({ id: In(playerIds) });
             if (players.length !== playerIds.length) {
                 const foundIds = players.map(p => p.id);
                 const missingIds = playerIds.filter(id => !foundIds.includes(id));
@@ -82,7 +86,7 @@ export class AwardService {
             award.players = players;
         }
 
-        return this.awardRepository.save(award);
+        return awardRepository.save(award);
     }
 
     /**
@@ -91,14 +95,25 @@ export class AwardService {
      * @returns Array of created awards
      */
     async createMultipleAwards(awardsData: CreateMultipleAwardsDto): Promise<Awards[]> {
-        const awards: Awards[] = [];
+        const queryRunner = AppDataSource.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
 
-        for (const awardData of awardsData) {
-            const award = await this.createAward(awardData);
-            awards.push(award);
+        try {
+            const awards: Awards[] = [];
+
+            for (const awardData of awardsData) {
+                awards.push(await this.createAward(awardData, queryRunner.manager));
+            }
+
+            await queryRunner.commitTransaction();
+            return awards;
+        } catch (err) {
+            await queryRunner.rollbackTransaction();
+            throw err;
+        } finally {
+            await queryRunner.release();
         }
-
-        return awards;
     }
 
     /**

--- a/BE/src/modules/players/player.service.ts
+++ b/BE/src/modules/players/player.service.ts
@@ -307,34 +307,49 @@ export class PlayerService extends CacheableService
             if (!playerData.teamIds || playerData.teamIds.length === 0) throw new MissingFieldError("Team IDs");
         });
 
-        // Fetch teams by their ids (for batch efficiency)
-        const teamIds = playersData.flatMap(playerData => playerData.teamIds);
-        const teams = await this.teamRepository.findBy({ id: In(teamIds) });
+        const queryRunner = AppDataSource.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
 
-        // Check for duplicate players (same name, same teams)
-        for (const playerData of playersData) {
-            const existingPlayer = await this.playerRepository.findOne({
-                where: { name: playerData.name, teams: { id: In(playerData.teamIds) } },
-            });
-            if (existingPlayer) {
-                throw new Error(`Player with name "${playerData.name}" already exists on one of the teams`);
+        try {
+            const playerRepository = queryRunner.manager.getRepository(Players);
+            const teamRepository = queryRunner.manager.getRepository(Teams);
+
+            // Fetch teams by their ids (for batch efficiency)
+            const teamIds = playersData.flatMap(playerData => playerData.teamIds);
+            const teams = await teamRepository.findBy({ id: In(teamIds) });
+
+            // Check for duplicate players (same name, same teams)
+            for (const playerData of playersData) {
+                const existingPlayer = await playerRepository.findOne({
+                    where: { name: playerData.name, teams: { id: In(playerData.teamIds) } },
+                });
+                if (existingPlayer) {
+                    throw new Error(`Player with name "${playerData.name}" already exists on one of the teams`);
+                }
             }
+
+            // Create players
+            const newPlayers = playersData.map(data => {
+                const playerTeams = teams.filter(team => data.teamIds.includes(team.id));
+
+                const newPlayer = new Players();
+                newPlayer.name = data.name;
+                newPlayer.position = data.position;
+                newPlayer.teams = playerTeams;
+
+                return newPlayer;
+            });
+
+            const saved = await playerRepository.save(newPlayers);
+            await queryRunner.commitTransaction();
+            return saved;
+        } catch (err) {
+            await queryRunner.rollbackTransaction();
+            throw err;
+        } finally {
+            await queryRunner.release();
         }
-
-        // Create players
-        const newPlayers = playersData.map(data => {
-            const playerTeams = teams.filter(team => data.teamIds.includes(team.id));
-
-            const newPlayer = new Players();
-            newPlayer.name = data.name;
-            newPlayer.position = data.position;
-            newPlayer.teams = playerTeams; // Associate player with multiple teams
-
-            return newPlayer;
-        });
-
-        // Save all new players at once
-        return this.playerRepository.save(newPlayers);
     }
 
     /**
@@ -345,13 +360,6 @@ export class PlayerService extends CacheableService
         playersData: { name: string, position: string, teamNames: string[] }[]
     ): Promise<Players[]> 
     {
-        
-
-        const season = await this.seasonRepository.findOne({ where: { id: seasonId } });
-        if (!season) {
-            throw new NotFoundError(`Season with ID ${seasonId} not found`);
-        }
-
         // Validate input
         playersData.forEach(playerData => {
             if (!playerData.name) throw new MissingFieldError("Player name");
@@ -361,78 +369,86 @@ export class PlayerService extends CacheableService
             }
         });
 
-        // Normalize and collect all unique team names (lowercased and trimmed)
-        const allTeamNames = [
-            ...new Set(playersData.flatMap(p => p.teamNames.map(n => n.trim().toLowerCase())))
-        ];
-        
+        const queryRunner = AppDataSource.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
 
-        // Fetch matching teams within the selected season only
-        const allTeams = await this.teamRepository
-            .createQueryBuilder("team")
-            .innerJoin("team.season", "season")
-            .where("season.id = :seasonId", { seasonId })
-            .andWhere("LOWER(team.name) IN (:...names)", { names: allTeamNames })
-            .getMany();
+        try {
+            const playerRepository = queryRunner.manager.getRepository(Players);
+            const teamRepository = queryRunner.manager.getRepository(Teams);
+            const seasonRepository = queryRunner.manager.getRepository(Seasons);
 
-        
-
-        const createdOrUpdatedPlayers: Players[] = [];
-
-        for (const playerData of playersData) 
-        {
-            
-
-            // Normalize incoming names
-            const normalizedTeamNames = playerData.teamNames.map(n => n.trim().toLowerCase());
-
-            // Match fetched teams
-            const playerTeams = allTeams.filter(team =>
-                normalizedTeamNames.includes(team.name.trim().toLowerCase())
-            );
-
-            if (playerTeams.length !== normalizedTeamNames.length) 
-            {
-                
-                throw new NotFoundError(`One or more teams not found in season ${seasonId} for player "${playerData.name}"`);
+            const season = await seasonRepository.findOne({ where: { id: seasonId } });
+            if (!season) {
+                throw new NotFoundError(`Season with ID ${seasonId} not found`);
             }
 
-            // Check if player already exists
-            let player = await this.playerRepository.findOne({
-                where: { name: playerData.name.toLowerCase() },
-                relations: ["teams"],
-            });
+            // Normalize and collect all unique team names (lowercased and trimmed)
+            const allTeamNames = [
+                ...new Set(playersData.flatMap(p => p.teamNames.map(n => n.trim().toLowerCase())))
+            ];
 
-            if (player) 
+            // Fetch matching teams within the selected season only
+            const allTeams = await teamRepository
+                .createQueryBuilder("team")
+                .innerJoin("team.season", "season")
+                .where("season.id = :seasonId", { seasonId })
+                .andWhere("LOWER(team.name) IN (:...names)", { names: allTeamNames })
+                .getMany();
+
+            const createdOrUpdatedPlayers: Players[] = [];
+
+            for (const playerData of playersData) 
             {
-                const newTeams = playerTeams.filter(team =>
-                    !player.teams.some(existing => existing.id === team.id)
+                const normalizedTeamNames = playerData.teamNames.map(n => n.trim().toLowerCase());
+
+                const playerTeams = allTeams.filter(team =>
+                    normalizedTeamNames.includes(team.name.trim().toLowerCase())
                 );
 
-                if (newTeams.length === 0) 
+                if (playerTeams.length !== normalizedTeamNames.length) 
                 {
-                    
-                    continue;
+                    throw new NotFoundError(`One or more teams not found in season ${seasonId} for player "${playerData.name}"`);
                 }
 
-                player.teams.push(...newTeams);
-                
-                createdOrUpdatedPlayers.push(await this.playerRepository.save(player));
-            } 
-            else 
-            {
-                const newPlayer = new Players();
-                newPlayer.name = playerData.name.toLowerCase();
-                newPlayer.position = playerData.position;
-                newPlayer.teams = playerTeams;
+                let player = await playerRepository.findOne({
+                    where: { name: playerData.name.toLowerCase() },
+                    relations: ["teams"],
+                });
 
-                
-                createdOrUpdatedPlayers.push(await this.playerRepository.save(newPlayer));
+                if (player) 
+                {
+                    const newTeams = playerTeams.filter(team =>
+                        !player.teams.some(existing => existing.id === team.id)
+                    );
+
+                    if (newTeams.length === 0) 
+                    {
+                        continue;
+                    }
+
+                    player.teams.push(...newTeams);
+                    createdOrUpdatedPlayers.push(await playerRepository.save(player));
+                } 
+                else 
+                {
+                    const newPlayer = new Players();
+                    newPlayer.name = playerData.name.toLowerCase();
+                    newPlayer.position = playerData.position;
+                    newPlayer.teams = playerTeams;
+
+                    createdOrUpdatedPlayers.push(await playerRepository.save(newPlayer));
+                }
             }
-        }
 
-        
-        return createdOrUpdatedPlayers;
+            await queryRunner.commitTransaction();
+            return createdOrUpdatedPlayers;
+        } catch (err) {
+            await queryRunner.rollbackTransaction();
+            throw err;
+        } finally {
+            await queryRunner.release();
+        }
     }
 
 

--- a/BE/src/modules/stats/stat.service.ts
+++ b/BE/src/modules/stats/stat.service.ts
@@ -637,11 +637,12 @@ export class StatService extends CacheableService
 
             // Start transaction
             const queryRunner = AppDataSource.createQueryRunner();
+            await queryRunner.connect();
             await queryRunner.startTransaction();
 
             try {
                 // Fetch season
-                const season = await this.seasonRepository.findOne({
+                const season = await queryRunner.manager.findOne(Seasons, {
                     where: { id: gameData.seasonId },
                     relations: ["teams"]
                 });
@@ -654,7 +655,7 @@ export class StatService extends CacheableService
                 console.log('Searching for teams:', gameData.teamNames, 'in season:', gameData.seasonId);
                 
                 // Let's also check what teams exist in this season
-                const allTeamsInSeason = await this.teamRepository.find({
+                const allTeamsInSeason = await queryRunner.manager.find(Teams, {
                     where: { season: { id: gameData.seasonId } },
                     relations: ["season"]
                 });
@@ -663,7 +664,7 @@ export class StatService extends CacheableService
                 // Search for each team individually (following the pattern from TeamService)
                 const teams: any[] = [];
                 for (const teamName of gameData.teamNames) {
-                    const team = await this.teamRepository.findOne({
+                    const team = await queryRunner.manager.findOne(Teams, {
                         where: { 
                             name: teamName,
                             season: { id: gameData.seasonId }
@@ -713,7 +714,7 @@ export class StatService extends CacheableService
                     }
 
                     // Find player by name
-                    const player = await this.playerRepository.findOne({
+                    const player = await queryRunner.manager.findOne(Players, {
                         where: { name: statData.playerName },
                         relations: ["teams"]
                     });
@@ -734,7 +735,7 @@ export class StatService extends CacheableService
                     }
 
                     // Check for duplicate stats
-                    const existingStat = await this.statRepository.findOne({
+                    const existingStat = await queryRunner.manager.findOne(Stats, {
                         where: {
                             player: { id: player.id },
                             game: { id: savedGame.id }
@@ -818,22 +819,22 @@ export class StatService extends CacheableService
             }
 
             // Fetch the existing game with teams
-            const game = await this.gameRepository.findOne({
-                where: { id: gameId },
-                relations: ["teams"]
-            });
-
-            if (!game) {
-                throw new NotFoundError(`Game with ID ${gameId} not found`);
-            }
-
-            console.log('Found game:', { id: game.id, name: game.name, teams: game.teams.map(t => t.name) });
-
-            // Start transaction
             const queryRunner = AppDataSource.createQueryRunner();
+            await queryRunner.connect();
             await queryRunner.startTransaction();
 
             try {
+                const game = await queryRunner.manager.findOne(Games, {
+                    where: { id: gameId },
+                    relations: ["teams"]
+                });
+
+                if (!game) {
+                    throw new NotFoundError(`Game with ID ${gameId} not found`);
+                }
+
+                console.log('Found game:', { id: game.id, name: game.name, teams: game.teams.map(t => t.name) });
+
                 // Create stats records
                 const statsToCreate: Stats[] = [];
                 const missingPlayers: string[] = [];
@@ -846,7 +847,7 @@ export class StatService extends CacheableService
                     }
 
                     // Find player by name
-                    const player = await this.playerRepository.findOne({
+                    const player = await queryRunner.manager.findOne(Players, {
                         where: { name: statData.playerName },
                         relations: ["teams"]
                     });
@@ -868,7 +869,7 @@ export class StatService extends CacheableService
                     }
 
                     // Check for duplicate stats
-                    const existingStat = await this.statRepository.findOne({
+                    const existingStat = await queryRunner.manager.findOne(Stats, {
                         where: {
                             player: { id: player.id },
                             game: { id: game.id }

--- a/BE/src/modules/teams/team.service.ts
+++ b/BE/src/modules/teams/team.service.ts
@@ -1,4 +1,4 @@
-import { Repository, In, ILike, FindOptionsWhere } from 'typeorm';
+import { Repository, In, ILike, FindOptionsWhere, EntityManager } from 'typeorm';
 import { AppDataSource } from '../../db/data-source.js';
 import { Teams } from './team.entity.js';
 import { Players } from '../players/player.entity.js';
@@ -84,7 +84,12 @@ export class TeamService {
     /**
      * Create a new team with validation
      */
-    async createTeam(teamData: CreateTeamDto): Promise<Teams> {
+    async createTeam(teamData: CreateTeamDto, manager?: EntityManager): Promise<Teams> {
+        const teamRepository = manager ? manager.getRepository(Teams) : this.teamRepository;
+        const playerRepository = manager ? manager.getRepository(Players) : this.playerRepository;
+        const seasonRepository = manager ? manager.getRepository(Seasons) : this.seasonRepository;
+        const gameRepository = manager ? manager.getRepository(Games) : this.gameRepository;
+
         const { name, seasonNumber, placement, playerIds, gameIds, logoUrl, regionId, region } = teamData;
 
         // Validation for missing name
@@ -100,7 +105,7 @@ export class TeamService {
         // Fetch the season to associate with the team
         const resolvedRegionId = await this.resolveRegionId(regionId, region);
 
-        const season = await this.seasonRepository.findOne({
+        const season = await seasonRepository.findOne({
             where: { seasonNumber, regionId: resolvedRegionId },
             relations: ["teams"]
         });
@@ -108,7 +113,7 @@ export class TeamService {
             throw new NotFoundError(`Season ${seasonNumber} not found in this region`);
         }
 
-        const existingTeam = await this.teamRepository.findOne({
+        const existingTeam = await teamRepository.findOne({
             where: { name, season: { seasonNumber, regionId: resolvedRegionId } }
         });
 
@@ -134,7 +139,7 @@ export class TeamService {
 
         // Add players relationships
         if (playerIds && playerIds.length > 0) {
-            const players = await this.playerRepository.find({
+            const players = await playerRepository.find({
                 where: { id: In(playerIds) },
                 relations: ["teams", "teams.season"]
             });
@@ -152,7 +157,7 @@ export class TeamService {
 
         // Add games relationships
         if (gameIds && gameIds.length > 0) {
-            const games = await this.gameRepository.find({
+            const games = await gameRepository.find({
                 where: { id: In(gameIds) },
                 relations: ["teams", "season"]
             });
@@ -168,7 +173,7 @@ export class TeamService {
             newTeam.games = games;
         }
 
-        return this.teamRepository.save(newTeam);
+        return teamRepository.save(newTeam);
     }
 
     /**
@@ -213,14 +218,25 @@ export class TeamService {
      * Create multiple teams
      */
     async createMultipleTeams(teamsData: CreateMultipleTeamsDto): Promise<Teams[]> {
-        const createdTeams: Teams[] = [];
+        const queryRunner = AppDataSource.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
 
-        for (const data of teamsData) {
-            const team = await this.createTeam(data);
-            createdTeams.push(team);
+        try {
+            const createdTeams: Teams[] = [];
+
+            for (const data of teamsData) {
+                createdTeams.push(await this.createTeam(data, queryRunner.manager));
+            }
+
+            await queryRunner.commitTransaction();
+            return createdTeams;
+        } catch (err) {
+            await queryRunner.rollbackTransaction();
+            throw err;
+        } finally {
+            await queryRunner.release();
         }
-
-        return createdTeams;
     }
 
     /**

--- a/BE/src/modules/user/user.service.ts
+++ b/BE/src/modules/user/user.service.ts
@@ -215,25 +215,39 @@ export class UserService {
         const oldRole = target.role;
         target.role = desired;
         target.tokenVersion += 1;
-        const saved = await this.userRepository.save(target);
 
-        const auditEntry = new RoleAuditLog();
-        auditEntry.actorId = requester.id;
-        auditEntry.targetId = targetId;
-        auditEntry.oldRole = oldRole;
-        auditEntry.newRole = desired;
-        auditEntry.ip = audit?.ip ?? null;
-        await this.auditLogRepository.save(auditEntry);
+        const queryRunner = AppDataSource.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
 
-        console.info("[AUDIT] role_change", {
-            actorId: requester.id,
-            targetId,
-            oldRole,
-            newRole: desired,
-            ip: audit?.ip ?? null,
-            timestamp: new Date().toISOString(),
-        });
+        try {
+            const saved = await queryRunner.manager.save(target);
 
-        return saved;
+            const auditEntry = new RoleAuditLog();
+            auditEntry.actorId = requester.id;
+            auditEntry.targetId = targetId;
+            auditEntry.oldRole = oldRole;
+            auditEntry.newRole = desired;
+            auditEntry.ip = audit?.ip ?? null;
+            await queryRunner.manager.save(auditEntry);
+
+            await queryRunner.commitTransaction();
+
+            console.info("[AUDIT] role_change", {
+                actorId: requester.id,
+                targetId,
+                oldRole,
+                newRole: desired,
+                ip: audit?.ip ?? null,
+                timestamp: new Date().toISOString(),
+            });
+
+            return saved;
+        } catch (err) {
+            await queryRunner.rollbackTransaction();
+            throw err;
+        } finally {
+            await queryRunner.release();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Wrap role change + audit log in a single transaction so privilege updates cannot persist without an audit entry.
- Wrap batch create endpoints for teams, players, and awards in atomic transactions.
- Fix CSV stat upload paths to call `queryRunner.connect()` and use `queryRunner.manager` for reads that feed writes inside the transaction.

## Test plan
- [ ] Change a user role as superadmin and verify both role and audit log row update together
- [ ] Batch-create teams/players/awards and confirm all-or-nothing on validation failure mid-batch
- [ ] CSV batch upload and add-stats-to-existing-game succeed with consistent reads inside transaction