### PR TITLE
Connect QueryRunner before game batch transactions

### DIFF
--- a/BE/src/modules/games/game.service.ts
+++ b/BE/src/modules/games/game.service.ts
@@ -134,6 +134,7 @@ export class GameService {
         });
 
         const queryRunner = AppDataSource.createQueryRunner();
+        await queryRunner.connect();
         await queryRunner.startTransaction();
 
         try {


### PR DESCRIPTION
## Summary
- Call `queryRunner.connect()` before `startTransaction()` in `createMultipleGames`
- Matches the pattern already used by mergePlayers and Challonge import

## Test plan
- [ ] Create multiple games in one batch request
- [ ] Confirm no connection errors under normal load