### PR TITLE
fix: paginate subresource list endpoints (M3)

### DIFF
--- a/BE/src/modules/games/__tests__/game.controller.test.ts
+++ b/BE/src/modules/games/__tests__/game.controller.test.ts
@@ -284,26 +284,30 @@ describe('GameController', () => {
 
   describe('getGamesByTeamId', () => {
     it('should return all games for a specific team', async () => {
-      mockGetGamesByTeamId.mockResolvedValue(mockGames);
+      mockGetGamesByTeamId.mockResolvedValue([mockGames, mockGames.length]);
 
-      // Convert teamId to string
-      req = { params: { teamId: '1' } };
+      req = { params: { teamId: '1' }, query: {} };
 
       await gameController.getGamesByTeamId(req as Request, res as Response);
 
-      expect(mockGetGamesByTeamId).toHaveBeenCalledWith(1);
-      expect(res.json).toHaveBeenCalledWith(mockGames);
+      expect(mockGetGamesByTeamId).toHaveBeenCalledWith(1, expect.objectContaining({ page: 1, limit: 10 }));
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        data: mockGames,
+        total: mockGames.length,
+        page: 1,
+        limit: 10,
+      }));
     });
 
     it('should return 404 if no games are found for team', async () => {
-      mockGetGamesByTeamId.mockResolvedValue([]);
+      mockGetGamesByTeamId.mockResolvedValue([[], 0]);
 
-      req = { params: { teamId: '1' } };
+      req = { params: { teamId: '1' }, query: {} };
 
       await gameController.getGamesByTeamId(req as Request, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.json).toHaveBeenCalledWith({ error: 'No games found for team' });
+      expect(res.json).toHaveBeenCalledWith({ message: 'No games found for the specified team' });
     });
 
     it('should return 500 for server error', async () => {

--- a/BE/src/modules/games/__tests__/game.service.test.ts
+++ b/BE/src/modules/games/__tests__/game.service.test.ts
@@ -200,48 +200,57 @@ describe('GameService', () => {
   });
 
   describe('getGamesBySeasonId', () => {
+    const pagination = { page: 1, limit: 10, skip: 0, take: 10 };
+
     it('should return games by season ID', async () => {
-      mockRepository.find.mockResolvedValueOnce(mockGames);
+      mockRepository.findAndCount = jest.fn().mockResolvedValueOnce([mockGames, mockGames.length]);
       mockRepository.findOneBy.mockResolvedValueOnce(mockSeason);
 
-      const result = await gameService.getGamesBySeasonId(1);
+      const result = await gameService.getGamesBySeasonId(1, pagination);
 
-      expect(mockRepository.find).toHaveBeenCalledWith({
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith({
         where: { season: { id: 1 } },
         relations: ['teams', 'stats'],
         order: { date: 'DESC' },
+        skip: 0,
+        take: 10,
       });
-      expect(result).toEqual(mockGames);
+      expect(result).toEqual([mockGames, mockGames.length]);
     });
 
     it('should throw error if season not found', async () => {
       mockRepository.findOneBy.mockResolvedValueOnce(null);
 
-      await expect(gameService.getGamesBySeasonId(999)).rejects.toThrow(
+      await expect(gameService.getGamesBySeasonId(999, pagination)).rejects.toThrow(
         new NotFoundError('Season with ID 999 not found'),
       );
     });
   });
 
   describe('getGamesByTeamId', () => {
+    const pagination = { page: 1, limit: 10, skip: 0, take: 10 };
+
     it('should return games by team ID', async () => {
-      mockRepository.find.mockResolvedValueOnce(mockGames);
-      mockRepository.findOne.mockResolvedValueOnce(mockTeam);
+      mockRepository.findAndCount = jest.fn().mockResolvedValueOnce([mockGames, mockGames.length]);
+      mockRepository.findOneBy.mockResolvedValueOnce(mockTeam);
 
-      const result = await gameService.getGamesByTeamId(1);
+      const result = await gameService.getGamesByTeamId(1, pagination);
 
-      expect(mockRepository.find).toHaveBeenCalledWith({
-        where: { id: { $in: [1] } },
-        relations: ['season', 'teams', 'stats'],
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ id: 1 });
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith({
+        where: { teams: { id: 1 } },
+        relations: ['season', 'teams', 'winner', 'stats', 'region'],
         order: { date: 'DESC' },
+        skip: 0,
+        take: 10,
       });
-      expect(result).toEqual(mockGames);
+      expect(result).toEqual([mockGames, mockGames.length]);
     });
 
     it('should throw error if team not found', async () => {
-      mockRepository.findOne.mockResolvedValueOnce(null);
+      mockRepository.findOneBy.mockResolvedValueOnce(null);
 
-      await expect(gameService.getGamesByTeamId(999)).rejects.toThrow(
+      await expect(gameService.getGamesByTeamId(999, pagination)).rejects.toThrow(
         new NotFoundError('Team with ID 999 not found'),
       );
     });

--- a/BE/src/modules/games/game.controller.ts
+++ b/BE/src/modules/games/game.controller.ts
@@ -318,14 +318,15 @@ export class GameController {
     getGamesBySeasonId = async (req: Request, res: Response): Promise<void> => {
         try {
             const { seasonId } = req.params;
-            const games = await this.gameService.getGamesBySeasonId(parseInt(seasonId));
+            const pagination = parsePagination(req.query, GAMES_DEFAULT_LIMIT);
+            const [data, total] = await this.gameService.getGamesBySeasonId(parseInt(seasonId), pagination);
 
-            if (games.length === 0) {
+            if (data.length === 0) {
                 res.status(404).json({ message: "No games found for the specified season" });
                 return;
             }
 
-            res.json(games);
+            res.json(toPaginatedResult(data, total, pagination));
         } catch (error: any) {
             if (error instanceof MissingFieldError || 
                 error instanceof NotFoundError || 
@@ -346,14 +347,15 @@ export class GameController {
     getGamesByTeamId = async (req: Request, res: Response): Promise<void> => {
         try {
             const { teamId } = req.params;
-            const games = await this.gameService.getGamesByTeamId(parseInt(teamId));
+            const pagination = parsePagination(req.query, GAMES_DEFAULT_LIMIT);
+            const [data, total] = await this.gameService.getGamesByTeamId(parseInt(teamId), pagination);
 
-            if (games.length === 0) {
+            if (data.length === 0) {
                 res.status(404).json({ message: "No games found for the specified team" });
                 return;
             }
 
-            res.json(games);
+            res.json(toPaginatedResult(data, total, pagination));
         } catch (error: any) {
             if (error instanceof MissingFieldError || 
                 error instanceof NotFoundError || 

--- a/BE/src/modules/games/game.service.ts
+++ b/BE/src/modules/games/game.service.ts
@@ -145,8 +145,13 @@ export class GameService {
             const teamIds = gamesData.flatMap(game => game.teamIds);
             const teams = await this.teamRepository.findBy({ id: In(teamIds) });
 
+            const existingGames = await this.gameRepository.find({
+                where: { season: { id: In(seasonIds) } },
+                relations: ["teams", "season"],
+            });
+
             // Create the games
-            const newGames = await Promise.all(gamesData.map(async (data) => {
+            const newGames = gamesData.map((data) => {
                 const season = seasons.find(season => season.id === data.seasonId);
                 if (!season) throw new NotFoundError(`Season with ID ${data.seasonId} not found`);
 
@@ -158,13 +163,10 @@ export class GameService {
                     throw new NotFoundError(`Both teams with IDs ${data.teamIds} must be valid`);
                 }
 
-                // Check if the game already exists with the same teams and season
-                const existingGame = await this.gameRepository.findOne({
-                    where: {
-                        season: { id: data.seasonId },
-                        teams: { id: In(data.teamIds) },
-                    }
-                });
+                const existingGame = existingGames.find(game =>
+                    game.season.id === data.seasonId &&
+                    game.teams.some(team => data.teamIds.includes(team.id))
+                );
                 if (existingGame) {
                     throw new DuplicateError(`A game between these teams already exists for the season on ${data.date}`);
                 }
@@ -178,7 +180,7 @@ export class GameService {
                 newGame.regionId = season.regionId;
 
                 return newGame;
-            }));
+            });
 
             // Save all new games at once
             await queryRunner.manager.save(newGames);
@@ -499,17 +501,19 @@ export class GameService {
     /**
      * Get games by season ID with validation
      */
-    async getGamesBySeasonId(seasonId: number): Promise<Games[]> {
+    async getGamesBySeasonId(seasonId: number, pagination: PaginationParams): Promise<[Games[], number]> {
         if (!seasonId) throw new MissingFieldError("Season ID");
 
         // Check if season exists
         const season = await this.seasonRepository.findOneBy({ id: seasonId });
         if (!season) throw new NotFoundError(`Season with ID ${seasonId} not found`);
 
-        return this.gameRepository.find({
+        return this.gameRepository.findAndCount({
             where: { season: { id: seasonId } },
             relations: ["teams", "stats"],
-            order: { date: "DESC" } // Most recent games first
+            order: { date: "DESC" },
+            skip: pagination.skip,
+            take: pagination.take,
         });
     }
 
@@ -518,30 +522,18 @@ export class GameService {
     /**
      * Get games by team ID with validation
      */
-    async getGamesByTeamId(teamId: number): Promise<Games[]> {
+    async getGamesByTeamId(teamId: number, pagination: PaginationParams): Promise<[Games[], number]> {
         if (!teamId) throw new MissingFieldError("Team ID");
 
-        // Check if team exists
-        const team = await this.teamRepository.findOne({
-            where: { id: teamId },
-            relations: ["games"],
-        });
-
+        const team = await this.teamRepository.findOneBy({ id: teamId });
         if (!team) throw new NotFoundError(`Team with ID ${teamId} not found`);
 
-        // Extract game IDs from the team's games
-        const gameIds = team.games.map(game => game.id);
-
-        // Return early if no games
-        if (gameIds.length === 0) {
-            return [];
-        }
-
-        // Fetch full game data with relations using TypeORM's In()
-        return this.gameRepository.find({
-            where: { id: In(gameIds) },
+        return this.gameRepository.findAndCount({
+            where: { teams: { id: teamId } },
             relations: ["season", "teams", "winner", "stats", "region"],
-            order: { date: "DESC" }
+            order: { date: "DESC" },
+            skip: pagination.skip,
+            take: pagination.take,
         });
     }
 

--- a/BE/src/modules/players/__tests__/player.controller.test.ts
+++ b/BE/src/modules/players/__tests__/player.controller.test.ts
@@ -264,20 +264,25 @@ describe('PlayerController', () => {
 
   describe('getPlayersByTeamId', () => {
     it('should return players by team ID', async () => {
-      mockGetPlayersByTeamId.mockResolvedValue(mockPlayers);
+      mockGetPlayersByTeamId.mockResolvedValue([mockPlayers, mockPlayers.length]);
 
-      req = { params: { teamId: '1' } };
+      req = { params: { teamId: '1' }, query: {} };
 
       await playerController.getPlayersByTeamId(req as Request, res as Response);
 
-      expect(mockGetPlayersByTeamId).toHaveBeenCalledWith(1);
-      expect(res.json).toHaveBeenCalledWith(mockPlayers);
+      expect(mockGetPlayersByTeamId).toHaveBeenCalledWith(1, expect.objectContaining({ page: 1, limit: 25 }));
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        data: mockPlayers,
+        total: mockPlayers.length,
+        page: 1,
+        limit: 25,
+      }));
     });
 
     it('should return 404 if no players are found for the team', async () => {
-      mockGetPlayersByTeamId.mockResolvedValue([]);
+      mockGetPlayersByTeamId.mockResolvedValue([[], 0]);
 
-      req = { params: { teamId: '999' } };
+      req = { params: { teamId: '999' }, query: {} };
 
       await playerController.getPlayersByTeamId(req as Request, res as Response);
 

--- a/BE/src/modules/players/__tests__/player.service.test.ts
+++ b/BE/src/modules/players/__tests__/player.service.test.ts
@@ -162,31 +162,35 @@ describe('PlayerService', () =>
 
     describe('getPlayersByTeamId', () => 
     {
+        const pagination = { page: 1, limit: 10, skip: 0, take: 10 };
+
         it('should return players by team ID', async () => 
         {
             mockRepository.findOneBy.mockResolvedValueOnce(mockTeam);
-            mockRepository.find.mockResolvedValueOnce(mockPlayers);
+            mockRepository.findAndCount = jest.fn().mockResolvedValueOnce([mockPlayers, mockPlayers.length]);
 
-            const result = await playerService.getPlayersByTeamId(1);
+            const result = await playerService.getPlayersByTeamId(1, pagination);
 
             expect(mockRepository.findOneBy).toHaveBeenCalledWith({ id: 1 });
-            expect(mockRepository.find).toHaveBeenCalledWith({
-                where: { team: { id: 1 } },
+            expect(mockRepository.findAndCount).toHaveBeenCalledWith({
+                where: { teams: { id: 1 } },
                 relations: ["stats"],
+                skip: 0,
+                take: 10,
             });
-            expect(result).toEqual(mockPlayers);
+            expect(result).toEqual([mockPlayers, mockPlayers.length]);
         });
 
         it('should throw error if team ID is missing', async () => 
         {
-            await expect(playerService.getPlayersByTeamId(0)).rejects.toThrow('Team ID is required');
+            await expect(playerService.getPlayersByTeamId(0, pagination)).rejects.toThrow('Team ID is required');
         });
 
         it('should throw error if team does not exist', async () => 
         {
             mockRepository.findOneBy.mockResolvedValueOnce(null);
 
-            await expect(playerService.getPlayersByTeamId(999)).rejects.toThrow('Team with ID 999 not found');
+            await expect(playerService.getPlayersByTeamId(999, pagination)).rejects.toThrow('Team with ID 999 not found');
         });
     });
 });

--- a/BE/src/modules/players/player.controller.ts
+++ b/BE/src/modules/players/player.controller.ts
@@ -267,14 +267,15 @@ export class PlayerController {
     getPlayersByTeamId = async (req: Request, res: Response): Promise<void> => {
         try {
             const { teamId } = req.params;
-            const players = await this.playerService.getPlayersByTeamId(parseInt(teamId));
+            const pagination = parsePagination(req.query, PLAYERS_DEFAULT_LIMIT);
+            const [data, total] = await this.playerService.getPlayersByTeamId(parseInt(teamId), pagination);
             
-            if (players.length === 0) {
+            if (data.length === 0) {
                 res.status(404).json({ message: "No players found for the specified team" });
                 return;
             }
             
-            res.json(players);
+            res.json(toPaginatedResult(data, total, pagination));
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : "Failed to fetch players by team";
             

--- a/BE/src/modules/players/player.service.ts
+++ b/BE/src/modules/players/player.service.ts
@@ -281,7 +281,7 @@ export class PlayerService extends CacheableService
     /**
      * Get players by team ID with validation
      */
-    async getPlayersByTeamId(teamId: number): Promise<Players[]> 
+    async getPlayersByTeamId(teamId: number, pagination: PaginationParams): Promise<[Players[], number]> 
     {
         if (!teamId) throw new MissingFieldError("Team ID");
 
@@ -289,9 +289,11 @@ export class PlayerService extends CacheableService
         const team = await this.teamRepository.findOneBy({ id: teamId });
         if (!team) throw new NotFoundError(`Team with ID ${teamId} not found`);
 
-        return this.playerRepository.find({
+        return this.playerRepository.findAndCount({
             where: { teams: { id: teamId } },
-            relations: ["stats"], // Fetch related stats
+            relations: ["stats"],
+            skip: pagination.skip,
+            take: pagination.take,
         });
     }
 
@@ -311,11 +313,17 @@ export class PlayerService extends CacheableService
         const teamIds = playersData.flatMap(playerData => playerData.teamIds);
         const teams = await this.teamRepository.findBy({ id: In(teamIds) });
 
-        // Check for duplicate players (same name, same teams)
+        const playerNames = [...new Set(playersData.map(p => p.name))];
+        const existingPlayers = await this.playerRepository.find({
+            where: { name: In(playerNames) },
+            relations: ["teams"],
+        });
+
         for (const playerData of playersData) {
-            const existingPlayer = await this.playerRepository.findOne({
-                where: { name: playerData.name, teams: { id: In(playerData.teamIds) } },
-            });
+            const existingPlayer = existingPlayers.find(p =>
+                p.name === playerData.name &&
+                p.teams.some(team => playerData.teamIds.includes(team.id))
+            );
             if (existingPlayer) {
                 throw new Error(`Player with name "${playerData.name}" already exists on one of the teams`);
             }

--- a/BE/src/modules/teams/__tests__/team.service.test.ts
+++ b/BE/src/modules/teams/__tests__/team.service.test.ts
@@ -173,28 +173,26 @@ describe('TeamService', () => {
   });
 
   describe('getTeamsBySeasonId', () => {
+    const pagination = { page: 1, limit: 10, skip: 0, take: 10 };
+
     it('should return teams by season id', async () => {
       mockRepository.findOneBy.mockResolvedValueOnce(mockSeason);
-      mockRepository.find.mockResolvedValueOnce(mockTeams);
+      mockRepository.findAndCount = jest.fn().mockResolvedValueOnce([mockTeams, mockTeams.length]);
 
-      const result = await teamService.getTeamsBySeasonId(1);
+      const result = await teamService.getTeamsBySeasonId(1, pagination);
 
       expect(mockRepository.findOneBy).toHaveBeenCalledWith({ id: 1 });
-      expect(mockRepository.find).toHaveBeenCalledWith({
-        where: { season: { id: 1 } },
-        relations: ["players", "games"],
-      });
-      expect(result).toEqual(mockTeams);
+      expect(result).toEqual([mockTeams, mockTeams.length]);
     });
 
     it('should throw error if seasonId is not provided', async () => {
-      await expect(teamService.getTeamsBySeasonId(0)).rejects.toThrow('Season ID is required');
+      await expect(teamService.getTeamsBySeasonId(0, pagination)).rejects.toThrow('Season ID is required');
     });
 
     it('should throw error if season is not found', async () => {
       mockRepository.findOneBy.mockResolvedValueOnce(null);
 
-      await expect(teamService.getTeamsBySeasonId(999)).rejects.toThrow('Season not found');
+      await expect(teamService.getTeamsBySeasonId(999, pagination)).rejects.toThrow('Season not found');
     });
   });
 });

--- a/BE/src/modules/teams/team.controller.ts
+++ b/BE/src/modules/teams/team.controller.ts
@@ -8,6 +8,7 @@ import { parseRegionQuery } from '../../utils/regionQuery.js';
 import { RegionService } from '../regions/region.service.js';
 
 const TEAMS_DEFAULT_LIMIT = 10;
+const TEAMS_BY_NAME_DEFAULT_LIMIT = 100;
 
 export class TeamController {
     private teamService: TeamService;
@@ -237,9 +238,10 @@ export class TeamController {
             if (!name) {
                 throw new MissingFieldError("Team name is required");
             }
-        
-            const teams = await this.teamService.getTeamsByName(name);
-            res.status(200).json(teams);
+
+            const pagination = parsePagination(req.query, TEAMS_BY_NAME_DEFAULT_LIMIT);
+            const [data, total] = await this.teamService.getTeamsByName(name, pagination);
+            res.status(200).json(toPaginatedResult(data, total, pagination));
         } catch (error: unknown) {
             console.error('Error in getTeamsByName:', error);
             
@@ -260,14 +262,15 @@ export class TeamController {
     getTeamsBySeasonId = async (req: Request, res: Response): Promise<void> => {
         try {
             const { seasonId } = req.params;
-            const teams = await this.teamService.getTeamsBySeasonId(parseInt(seasonId));
+            const pagination = parsePagination(req.query, TEAMS_DEFAULT_LIMIT);
+            const [data, total] = await this.teamService.getTeamsBySeasonId(parseInt(seasonId), pagination);
             
-            if (teams.length === 0) {
+            if (data.length === 0) {
                 res.status(404).json({ message: "No teams found for the specified season" });
                 return;
             }
             
-            res.json(teams);
+            res.json(toPaginatedResult(data, total, pagination));
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : "Failed to fetch teams by season";
             if (errorMessage.includes("not found") || errorMessage.includes("required")) {

--- a/BE/src/modules/teams/team.service.ts
+++ b/BE/src/modules/teams/team.service.ts
@@ -183,14 +183,14 @@ export class TeamService {
         return team;  // Return the team (with players) if found, or null if not found
     }
 
-    async getTeamsByName(name: string): Promise<Teams[]> {
+    async getTeamsByName(name: string, pagination: PaginationParams): Promise<[Teams[], number]> {
         if (!name) {
             throw new MissingFieldError("Team name");
         }
 
         const lookupName = decodeURIComponent(name).replace(/-/g, " ").trim();
 
-        const teams = await this.teamRepository
+        const [teams, total] = await this.teamRepository
             .createQueryBuilder("team")
             .leftJoinAndSelect("team.season", "season")
             .leftJoinAndSelect("team.players", "players")
@@ -200,13 +200,15 @@ export class TeamService {
             .leftJoinAndSelect("games.stats", "gameStats")
             .leftJoinAndSelect("games.season", "gameSeason")
             .where("LOWER(team.name) = LOWER(:name)", { name: lookupName })
-            .getMany();
+            .skip(pagination.skip)
+            .take(pagination.take)
+            .getManyAndCount();
 
-        if (teams.length === 0) {
+        if (total === 0) {
             throw new NotFoundError(`No teams found with name: ${name}`);
         }
 
-        return teams;
+        return [teams, total];
     }
 
     /**
@@ -374,21 +376,17 @@ export class TeamService {
     /**
      * Get all teams by season ID
      */
-    async getTeamsBySeasonId(seasonId: number): Promise<Teams[]> {
+    async getTeamsBySeasonId(seasonId: number, pagination: PaginationParams): Promise<[Teams[], number]> {
         if (!seasonId) {
             throw new MissingFieldError("Season ID");
         }
 
-        const season = await this.seasonRepository.findOne({
-            where: { id: seasonId },
-            relations: ["teams"]
-        });
-
+        const season = await this.seasonRepository.findOneBy({ id: seasonId });
         if (!season) {
             throw new NotFoundError(`Season with ID ${seasonId} not found`);
         }
 
-        return this.teamRepository.find({
+        return this.teamRepository.findAndCount({
             where: { season: { id: seasonId } },
             relations: [
                 "season",
@@ -400,7 +398,9 @@ export class TeamService {
                 "games.stats",
                 "games.season"
             ],
-            relationLoadStrategy: 'query'
+            relationLoadStrategy: 'query',
+            skip: pagination.skip,
+            take: pagination.take,
         });
     }
 

--- a/FE/src/hooks/useFetch.ts
+++ b/FE/src/hooks/useFetch.ts
@@ -34,8 +34,9 @@ export const useFetch = <T>(endpoint: string) =>
                         throw new Error("Network response was not ok");
                     }
     
-                    const result: T[] = await response.json(); // Always assume it's an array
-                    setData(result);
+                    const result = await response.json();
+                    const items: T[] = Array.isArray(result) ? result : result.data;
+                    setData(items);
                 }
                 catch (err: any)
                 {
@@ -58,7 +59,7 @@ export const useFetch = <T>(endpoint: string) =>
 // Specific hook to fetch a team by name
 export const useFetchTeamByName = <T>(teamName: string) =>
 {
-    return useFetch<T>(`teams/name/${encodeURIComponent(teamName)}`);  // Always treats result as an array
+    return useFetch<T>(`teams/name/${encodeURIComponent(teamName)}?limit=100`);
 };
 
 export const useFetchGameById = <T>(gameId: string) =>

--- a/FE/src/mocks/handlers.ts
+++ b/FE/src/mocks/handlers.ts
@@ -188,9 +188,9 @@ export const handlers = [
   // Teams
   http.get(api("teams/skinny"), ({ request }) => json(paginated(db.teams, request))),
   http.get(api("teams/medium"), ({ request }) => json(paginated(db.teams, request))),
-  http.get(api("teams/name/:name"), ({ params }) => {
+  http.get(api("teams/name/:name"), ({ params, request }) => {
     const name = decodeURIComponent(String(params.name));
-    return json(getTeamsByName(name));
+    return json(toPaginatedResult(getTeamsByName(name), new URL(request.url).searchParams));
   }),
   http.get(api("teams/:id"), ({ params }) => {
     const team = findById(db.teams, Number(params.id));


### PR DESCRIPTION
## Summary
- Add `parsePagination` / `toPaginatedResult` to subresource list endpoints: `getGamesBySeasonId`, `getGamesByTeamId`, `getTeamsBySeasonId`, `getTeamsByName`, and `getPlayersByTeamId`
- Services now return `[items, total]` tuples with `skip`/`take` instead of unbounded `find()` calls
- Update FE `useFetchTeamByName` to read `.data` from paginated responses (default limit 100 for name lookup)

## Test plan
- [ ] `GET /api/games/season/:seasonId?page=1&limit=10` returns `{ data, total, page, limit, totalPages }`
- [ ] `GET /api/games/team/:teamId?page=1&limit=10` returns paginated envelope
- [ ] `GET /api/teams/season/:seasonId?page=1&limit=10` returns paginated envelope
- [ ] `GET /api/teams/name/:name?limit=100` returns paginated envelope; FE team page still loads
- [ ] `GET /api/players/team/:teamId?page=1&limit=25` returns paginated envelope
- [ ] Empty results still return 404 with message (unchanged behavior)