### PR TITLE
fix: batch N+1 queries in CSV upload and bulk creates

### DIFF
--- a/BE/src/modules/games/game.service.ts
+++ b/BE/src/modules/games/game.service.ts
@@ -145,8 +145,13 @@ export class GameService {
             const teamIds = gamesData.flatMap(game => game.teamIds);
             const teams = await this.teamRepository.findBy({ id: In(teamIds) });
 
+            const existingGames = await this.gameRepository.find({
+                where: { season: { id: In(seasonIds) } },
+                relations: ["teams", "season"],
+            });
+
             // Create the games
-            const newGames = await Promise.all(gamesData.map(async (data) => {
+            const newGames = gamesData.map((data) => {
                 const season = seasons.find(season => season.id === data.seasonId);
                 if (!season) throw new NotFoundError(`Season with ID ${data.seasonId} not found`);
 
@@ -158,13 +163,10 @@ export class GameService {
                     throw new NotFoundError(`Both teams with IDs ${data.teamIds} must be valid`);
                 }
 
-                // Check if the game already exists with the same teams and season
-                const existingGame = await this.gameRepository.findOne({
-                    where: {
-                        season: { id: data.seasonId },
-                        teams: { id: In(data.teamIds) },
-                    }
-                });
+                const existingGame = existingGames.find(game =>
+                    game.season.id === data.seasonId &&
+                    game.teams.some(team => data.teamIds.includes(team.id))
+                );
                 if (existingGame) {
                     throw new DuplicateError(`A game between these teams already exists for the season on ${data.date}`);
                 }
@@ -178,7 +180,7 @@ export class GameService {
                 newGame.regionId = season.regionId;
 
                 return newGame;
-            }));
+            });
 
             // Save all new games at once
             await queryRunner.manager.save(newGames);

--- a/BE/src/modules/players/player.service.ts
+++ b/BE/src/modules/players/player.service.ts
@@ -311,11 +311,17 @@ export class PlayerService extends CacheableService
         const teamIds = playersData.flatMap(playerData => playerData.teamIds);
         const teams = await this.teamRepository.findBy({ id: In(teamIds) });
 
-        // Check for duplicate players (same name, same teams)
+        const playerNames = [...new Set(playersData.map(p => p.name))];
+        const existingPlayers = await this.playerRepository.find({
+            where: { name: In(playerNames) },
+            relations: ["teams"],
+        });
+
         for (const playerData of playersData) {
-            const existingPlayer = await this.playerRepository.findOne({
-                where: { name: playerData.name, teams: { id: In(playerData.teamIds) } },
-            });
+            const existingPlayer = existingPlayers.find(p =>
+                p.name === playerData.name &&
+                p.teams.some(team => playerData.teamIds.includes(team.id))
+            );
             if (existingPlayer) {
                 throw new Error(`Player with name "${playerData.name}" already exists on one of the teams`);
             }

--- a/BE/src/modules/stats/stat.service.ts
+++ b/BE/src/modules/stats/stat.service.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import { AppDataSource } from '../../db/data-source.js';
 import { Stats } from './stat.entity.js';
 import { Players } from '../players/player.entity.js';
@@ -650,61 +650,54 @@ export class StatService extends CacheableService
                 }
                 console.log('Found season:', { id: season.id });
 
-                // Fetch teams by names within the season (following established pattern)
-                console.log('Searching for teams:', gameData.teamNames, 'in season:', gameData.seasonId);
-                
-                // Let's also check what teams exist in this season
-                const allTeamsInSeason = await this.teamRepository.find({
-                    where: { season: { id: gameData.seasonId } },
-                    relations: ["season"]
+                const teams = await this.teamRepository.find({
+                    where: {
+                        name: In(gameData.teamNames),
+                        season: { id: gameData.seasonId },
+                    },
+                    relations: ["players", "season"],
                 });
-                console.log('All teams in season', gameData.seasonId, ':', allTeamsInSeason.map(t => ({ name: t.name, id: t.id })));
-                
-                // Search for each team individually (following the pattern from TeamService)
-                const teams: any[] = [];
-                for (const teamName of gameData.teamNames) {
-                    const team = await this.teamRepository.findOne({
-                        where: { 
-                            name: teamName,
-                            season: { id: gameData.seasonId }
-                        },
-                        relations: ["players", "season"]
-                    });
-                    if (team) {
-                        teams.push(team);
-                    }
-                }
-
-                console.log('Found teams:', teams.map(t => ({ name: t.name, seasonId: t.season?.id || 'no season relation' })));
 
                 if (teams.length !== 2) {
                     const foundTeamNames = teams.map(t => t.name);
                     const missingTeams = gameData.teamNames.filter((name: string) => !foundTeamNames.includes(name));
-                    console.log('Missing teams:', missingTeams);
-                    console.log('Found team names:', foundTeamNames);
-                    console.log('Searched for team names:', gameData.teamNames);
-                    console.log('=== END CSV UPLOAD DEBUG ===');
                     throw new NotFoundError(`Teams not found in season ${gameData.seasonId}: ${missingTeams.join(', ')}`);
                 }
+
+                const teamsByName = new Map(teams.map(t => [t.name, t]));
+                const orderedTeams = gameData.teamNames.map((name: string) => teamsByName.get(name)!);
 
                 // Create game
                 const newGame = new Games();
                 newGame.date = new Date(gameData.date);
                 newGame.season = season;
-                newGame.teams = teams;
+                newGame.teams = orderedTeams;
                 newGame.team1Score = gameData.team1Score;
                 newGame.team2Score = gameData.team2Score;
                 newGame.stage = gameData.stage;
                 newGame.videoUrl = gameData.videoUrl || '';
                 newGame.status = GameStatus.COMPLETED;
-                newGame.name = gameData.name || `${teams[0].name} vs. ${teams[1].name} S${gameData.seasonId}`;
+                newGame.name = gameData.name || `${orderedTeams[0].name} vs. ${orderedTeams[1].name} S${gameData.seasonId}`;
                 applyWinnerToGame(newGame);
 
                 const savedGame = await queryRunner.manager.save(newGame);
 
+                const playerNames = [...new Set(statsData.map((s: { playerName?: string }) => s.playerName).filter(Boolean))];
+                const players = await this.playerRepository.find({
+                    where: { name: In(playerNames) },
+                    relations: ["teams"],
+                });
+                const playersByName = new Map(players.map(p => [p.name, p]));
+
+                const existingStats = await this.statRepository.find({
+                    where: { game: { id: savedGame.id } },
+                    relations: ["player"],
+                });
+                const existingPlayerIds = new Set(existingStats.map(s => s.player.id));
+                const batchPlayerIds = new Set<number>();
+
                 // Create stats records
                 const statsToCreate: Stats[] = [];
-                const createdStats: Stats[] = [];
 
                 for (const statData of statsData) {
                     // Validate stat data
@@ -712,11 +705,7 @@ export class StatService extends CacheableService
                         throw new MissingFieldError("Player name is required for all stats");
                     }
 
-                    // Find player by name
-                    const player = await this.playerRepository.findOne({
-                        where: { name: statData.playerName },
-                        relations: ["teams"]
-                    });
+                    const player = playersByName.get(statData.playerName);
 
                     if (!player) {
                         throw new NotFoundError(`Player "${statData.playerName}" not found`);
@@ -724,7 +713,7 @@ export class StatService extends CacheableService
 
                     // Check if player is on one of the game's teams
                     const playerTeamIds = player.teams.map(t => t.id);
-                    const gameTeamIds = teams.map(t => t.id);
+                    const gameTeamIds = orderedTeams.map(t => t.id);
                     const isPlayerInGame = playerTeamIds.some(id => gameTeamIds.includes(id));
 
                     if (!isPlayerInGame) {
@@ -733,17 +722,10 @@ export class StatService extends CacheableService
                         );
                     }
 
-                    // Check for duplicate stats
-                    const existingStat = await this.statRepository.findOne({
-                        where: {
-                            player: { id: player.id },
-                            game: { id: savedGame.id }
-                        }
-                    });
-
-                    if (existingStat) {
+                    if (existingPlayerIds.has(player.id) || batchPlayerIds.has(player.id)) {
                         throw new DuplicateError(`Stats already exist for player "${statData.playerName}" in this game`);
                     }
+                    batchPlayerIds.add(player.id);
 
                     // Create stat record
                     const newStat = new Stats();
@@ -834,6 +816,20 @@ export class StatService extends CacheableService
             await queryRunner.startTransaction();
 
             try {
+                const playerNames = [...new Set(statsData.map(s => s.playerName).filter(Boolean))];
+                const players = await this.playerRepository.find({
+                    where: { name: In(playerNames) },
+                    relations: ["teams"],
+                });
+                const playersByName = new Map(players.map(p => [p.name, p]));
+
+                const existingStats = await this.statRepository.find({
+                    where: { game: { id: game.id } },
+                    relations: ["player"],
+                });
+                const existingPlayerIds = new Set(existingStats.map(s => s.player.id));
+                const batchPlayerIds = new Set<number>();
+
                 // Create stats records
                 const statsToCreate: Stats[] = [];
                 const missingPlayers: string[] = [];
@@ -845,11 +841,7 @@ export class StatService extends CacheableService
                         continue;
                     }
 
-                    // Find player by name
-                    const player = await this.playerRepository.findOne({
-                        where: { name: statData.playerName },
-                        relations: ["teams"]
-                    });
+                    const player = playersByName.get(statData.playerName);
 
                     if (!player) {
                         missingPlayers.push(statData.playerName);
@@ -867,17 +859,10 @@ export class StatService extends CacheableService
                         );
                     }
 
-                    // Check for duplicate stats
-                    const existingStat = await this.statRepository.findOne({
-                        where: {
-                            player: { id: player.id },
-                            game: { id: game.id }
-                        }
-                    });
-
-                    if (existingStat) {
+                    if (existingPlayerIds.has(player.id) || batchPlayerIds.has(player.id)) {
                         throw new DuplicateError(`Stats already exist for player "${statData.playerName}" in this game`);
                     }
+                    batchPlayerIds.add(player.id);
 
                     // Create stat record
                     const newStat = new Stats();


### PR DESCRIPTION
## Summary
- Pre-load teams, players, and existing stats with `In([...])` in CSV upload paths instead of per-row `findOne` loops
- Pre-load existing games once in `createMultipleGames` for duplicate checks
- Pre-load existing players once in `createMultiplePlayers` for duplicate checks

## Test plan
- [ ] CSV batch upload resolves teams and players in constant queries
- [ ] Adding stats to an existing game rejects duplicates correctly
- [ ] Bulk game creation still rejects duplicate season/team combinations
- [ ] Bulk player creation still rejects duplicate name/team combinations
