### PR TITLE
fix: harden BE Docker image (M7)

### DIFF
--- a/BE/.dockerignore
+++ b/BE/.dockerignore
@@ -1,3 +1,12 @@
 node_modules
 dist
 .env
+.env.*
+*.log
+coverage
+.git
+.gitignore
+**/__tests__
+**/*.test.ts
+**/*.spec.ts
+npm-debug.log*

--- a/BE/Dockerfile
+++ b/BE/Dockerfile
@@ -1,36 +1,33 @@
-# Use official Node.js v20 image with security updates
-FROM node:20-slim
+# Build stage — install devDependencies and compile TypeScript
+FROM node:20-slim AS build
 
-# Set working directory
 WORKDIR /app
 
-# Copy package files for dependency installation
 COPY package.json package-lock.json ./
+RUN npm ci
 
-# Install all dependencies (including dev) for building
-# Override NODE_ENV to ensure devDependencies are installed (needed for TypeScript compilation)
-RUN NODE_ENV=development npm ci && npm cache clean --force
-
-# Copy the source code
 COPY . .
-
-# Verify and prepare start script
-RUN echo "Verifying start script..." && \
-    ls -la start.sh && \
-    cat start.sh && \
-    sed -i 's/\r$//' start.sh && \
-    chmod +x start.sh && \
-    echo "Script permissions:" && \
-    ls -la start.sh
-
-# Build the application
 RUN npm run build
 
-# Expose the application port 
-EXPOSE 3000
+# Production stage — prod dependencies + compiled output only
+FROM node:20-slim AS production
 
-# Set NODE_ENV to production
+WORKDIR /app
+
 ENV NODE_ENV=production
 
-# Start the application in production mode
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=build /app/dist ./dist
+COPY start.sh ./start.sh
+RUN sed -i 's/\r$//' start.sh && chmod +x start.sh && chown -R node:node /app
+
+USER node
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3000/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 ENTRYPOINT ["./start.sh"]


### PR DESCRIPTION
## Summary
- Rewrite `BE/Dockerfile` as a multi-stage build: builder installs all deps and compiles; runtime image ships prod deps + `dist/` only
- Run the container as `USER node` with `chown` on `/app`
- Add `HEALTHCHECK` probing `GET /health` (Terminus endpoint)
- Expand `BE/.dockerignore` to exclude `.env`, tests, coverage, and git metadata
- Remove debug `cat start.sh` / verbose listing from the image build

## Test plan
- [ ] `docker build -f BE/Dockerfile BE` succeeds
- [ ] Container starts and serves API on port 3000
- [ ] `docker inspect` shows HEALTHCHECK configured
- [ ] `curl http://localhost:3000/health` returns OK when DB is reachable
- [ ] Process runs as non-root `node` user inside the container