### PR TITLE
Fix cache miss for falsy cached values

### DIFF
--- a/BE/src/utils/cacheService.ts
+++ b/BE/src/utils/cacheService.ts
@@ -36,7 +36,7 @@ export abstract class CacheableService {
     try {
       // Try to get from cache first
       const cached = await cacheService.get<T>(cacheKey, this.cachePrefix);
-      if (cached) {
+      if (cached !== null && cached !== undefined) {
         return cached;
       }
 


### PR DESCRIPTION
## Summary
- Treat `null`/`undefined` as cache miss only so `[]`, `0`, and `false` are served from cache

## Test plan
- [ ] Cache an empty list response and confirm the next request does not re-query the DB


Made with [Cursor](https://cursor.com)