### PR TITLE
Stop leaking internal 500 error messages

### DIFF
--- a/BE/src/middleware/errorHandling.ts
+++ b/BE/src/middleware/errorHandling.ts
@@ -36,9 +36,11 @@ export const errorHandler = (err: Error, req: Request, res: Response, next: Next
     console.error(err.message);
 
     const statusCode = errorCodeMapping[err.constructor.name] || 500;
+    const isOperational = statusCode < 500;
 
     const response: Record<string, unknown> = {
-        error: err.message,
+        // Never leak driver/internal messages on unexpected 500s
+        error: isOperational ? err.message : "Internal server error",
         stack: process.env.NODE_ENV === 'development' ? err.stack : undefined,
     };
 


### PR DESCRIPTION
## Summary
- Unexpected 500 responses return `Internal server error` instead of raw `err.message`.
- Known operational errors (mapped 4xx) keep their messages.

## Test plan
- [ ] Trigger a NotFoundError and confirm the specific message is returned
- [ ] Force an unhandled error and confirm the client sees a generic 500 message


Made with [Cursor](https://cursor.com)