### PR TITLE
Sanitize request logging and drop success body dumps

### DIFF
--- a/BE/src/middleware/logger.ts
+++ b/BE/src/middleware/logger.ts
@@ -1,6 +1,25 @@
 import { Request, Response, NextFunction } from 'express';
 import { sanitizeForLogging } from '../utils/sanitizeForLogging.js';
 
+const RESPONSE_LOG_MAX = 200;
+
+function truncateForLog(data: unknown): unknown {
+    if (typeof data === 'string') {
+        return data.length > RESPONSE_LOG_MAX
+            ? `${data.substring(0, RESPONSE_LOG_MAX)}…[truncated]`
+            : data;
+    }
+    try {
+        const json = JSON.stringify(sanitizeForLogging(data));
+        if (!json) return data;
+        return json.length > RESPONSE_LOG_MAX
+            ? `${json.substring(0, RESPONSE_LOG_MAX)}…[truncated]`
+            : JSON.parse(json);
+    } catch {
+        return '[unserializable]';
+    }
+}
+
 // Enhanced logger for comprehensive API tracking
 export function loggerMiddleware(req: Request, res: Response, next: NextFunction): void
 {
@@ -9,57 +28,49 @@ export function loggerMiddleware(req: Request, res: Response, next: NextFunction
     const path = req.path;
     const ip = req.ip || req.connection.remoteAddress;
     const userAgent = req.get('User-Agent') || 'Unknown';
-    
-    // Get user info if authenticated
+
+    // Avoid logging PII like username; id + role is enough for correlation
     const user = (req as any).user;
     const userId = user?.id || 'unauthenticated';
     const userRole = user?.role || 'none';
-    const username = user?.username || 'anonymous';
-    
-    // Log request start
+
     console.log(`\n🔍 [${timestamp}] API REQUEST START`);
     console.log(`📍 ${method} ${path}`);
-    console.log(`👤 User: ${username} (ID: ${userId}, Role: ${userRole})`);
+    console.log(`👤 User: ID ${userId}, Role: ${userRole}`);
     console.log(`🌐 IP: ${ip}`);
     console.log(`🔧 User-Agent: ${userAgent}`);
-    
-    // Log authentication method
-    const authMethod = req.header('X-API-Key') ? 'API Key' : 
+
+    const authMethod = req.header('X-API-Key') ? 'API Key' :
                       req.header('Authorization') ? 'JWT Token' : 'None';
     console.log(`🔐 Auth Method: ${authMethod}`);
-    
-    // Log query parameters
+
     if (Object.keys(req.query).length > 0) {
-        console.log(`🔍 Query Params:`, JSON.stringify(req.query, null, 2));
+        console.log(`🔍 Query Params:`, JSON.stringify(sanitizeForLogging(req.query), null, 2));
     }
-    
-    // Log request body (for non-GET requests)
-    if (method !== 'GET' && Object.keys(req.body).length > 0) {
+
+    if (method !== 'GET' && req.body && Object.keys(req.body).length > 0) {
         console.log(`📦 Request Body:`, JSON.stringify(sanitizeForLogging(req.body), null, 2));
     }
-    
-    // Track response
+
     const originalSend = res.send;
     res.send = function(data) {
         const responseTime = Date.now() - new Date(timestamp).getTime();
         const statusCode = res.statusCode;
-        
+
         console.log(`\n✅ [${new Date().toISOString()}] API REQUEST COMPLETE`);
         console.log(`📍 ${method} ${path} - Status: ${statusCode}`);
-        console.log(`👤 User: ${username} (ID: ${userId}, Role: ${userRole})`);
+        console.log(`👤 User: ID ${userId}, Role: ${userRole}`);
         console.log(`⏱️  Response Time: ${responseTime}ms`);
-        
-        // Log response data for errors or important operations
+
+        // Errors only, truncated + sanitized — do not dump full success bodies
         if (statusCode >= 400) {
-            console.log(`❌ Error Response:`, data);
-        } else if (method !== 'GET' && statusCode >= 200 && statusCode < 300) {
-            console.log(`✅ Success Response:`, typeof data === 'string' ? data.substring(0, 200) + '...' : data);
+            console.log(`❌ Error Response:`, truncateForLog(data));
         }
-        
+
         console.log(`🔚 [${new Date().toISOString()}] REQUEST END\n`);
-        
+
         return originalSend.call(this, data);
     };
-    
+
     next();
 }

--- a/BE/src/utils/sanitizeForLogging.ts
+++ b/BE/src/utils/sanitizeForLogging.ts
@@ -4,10 +4,18 @@ const SENSITIVE_KEYS = new Set([
     "newpassword",
     "confirmpassword",
     "token",
+    "accesstoken",
+    "refreshtoken",
     "authorization",
     "api_key",
     "apikey",
     "secret",
+    "email",
+    "username",
+    "cookie",
+    "csrf",
+    "csrftoken",
+    "x-csrf-token",
 ]);
 
 export function sanitizeForLogging(value: unknown): unknown {


### PR DESCRIPTION
## Summary
- Sanitize query params and error response logs
- Expand sensitive-key redaction (email, username, tokens, CSRF)
- Stop logging usernames and non-GET success response bodies

## Test plan
- [ ] Hit an authenticated endpoint and confirm logs show user id/role without username
- [ ] Request with `?token=secret` and confirm query log is redacted
- [ ] Confirm 4xx responses log a truncated sanitized payload only


Made with [Cursor](https://cursor.com)