### PR TITLE
fix: centralize BACKEND_URL constant

### DIFF
--- a/FE/src/components/ChallongeImport.tsx
+++ b/FE/src/components/ChallongeImport.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { authFetch } from '../hooks/authFetch';
 import { useAuth } from '../context/authContext';
+import { BACKEND_URL } from '../constants/api';
 import { useFormRegionSeason } from '../hooks/useFormRegionSeason';
 import RegionSeasonFields from './ui/RegionSeasonFields';
 import type { ImportChallongeInput, ChallongeImportResult } from '../types/interfaces';
@@ -66,7 +67,7 @@ const ChallongeImport: React.FC<ChallongeImportProps> = ({ onImportSuccess, onCa
         tags: formData.tags,
       };
 
-      const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
+      const backendUrl = BACKEND_URL;
       const response = await authFetch(`${backendUrl}/api/games/import-challonge`, {
         method: 'POST',
         body: JSON.stringify(payload),

--- a/FE/src/components/UserProfile.tsx
+++ b/FE/src/components/UserProfile.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { Link } from "react-router-dom";
 import { authFetch } from "../hooks/authFetch";
 import { useAuth } from "../context/authContext";
+import { BACKEND_URL } from "../constants/api";
 import "../styles/UserProfile.css";
 
 interface Article {
@@ -52,7 +53,7 @@ const ProfilePage: React.FC = () =>
             try
             {
                 const res = await authFetch(
-                    `${import.meta.env.VITE_BACKEND_URL || "http://localhost:3000"}/api/users/profile`,
+                    `${BACKEND_URL}/api/users/profile`,
                     { method: "GET" },
                     token
                 );

--- a/FE/src/components/portal/Dashboard.tsx
+++ b/FE/src/components/portal/Dashboard.tsx
@@ -2,8 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { FaVolleyballBall, FaUserAlt, FaChartBar, FaNewspaper, FaUsers, FaCalendarAlt, FaTrophy, FaClock } from 'react-icons/fa';
 import LuvLateAvatar from '../../images/LuvLate.png';
 import '../../styles/Dashboard.css';
+import { BACKEND_URL } from '../../constants/api';
 
-const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+const backendUrl = BACKEND_URL;
 
 const parseJson = async (response: Response) => {
   const contentType = response.headers.get('content-type') ?? '';

--- a/FE/src/constants/api.ts
+++ b/FE/src/constants/api.ts
@@ -1,0 +1,1 @@
+export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';

--- a/FE/src/context/authContext.tsx
+++ b/FE/src/context/authContext.tsx
@@ -14,8 +14,9 @@ import type {
 } from "../types/interfaces"
 import { MOCK_AUTH_TOKEN, mockAuthUser } from "../mocks/data"
 import { isMockMode, clearClientAuthState } from "../utils/authStorage"
+import { BACKEND_URL } from "../constants/api"
 
-const API_BASE = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000"
+const API_BASE = BACKEND_URL
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 

--- a/FE/src/context/regionContext.tsx
+++ b/FE/src/context/regionContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { BACKEND_URL } from "../constants/api";
 
 export type RegionCode = "na" | "eu" | "as";
 
@@ -35,7 +36,7 @@ export const RegionProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, [regions, selectedCode]);
 
   useEffect(() => {
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = BACKEND_URL;
     fetch(`${backendUrl}/api/regions`)
       .then((res) => res.json())
       .then((data: Region[]) => setRegions(data))

--- a/FE/src/hooks/allCreate.ts
+++ b/FE/src/hooks/allCreate.ts
@@ -6,6 +6,7 @@ import { Game,Player,Stats,Team,Season,Article,CreateGameInput,Award, CreateAwar
 import { useState } from "react";
 import { authFetch } from "./authFetch";
 import { useAuth } from "../context/authContext";
+import { BACKEND_URL } from "../constants/api";
 
 /**
  * useCreatePlayers
@@ -133,7 +134,7 @@ export const useCSVUpload = (showErrorModal?: (err: any) => void) => {
       return null;
     }
 
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = BACKEND_URL;
     try {
       const response = await authFetch(
         `${backendUrl}/api/stats/batch-csv`,
@@ -201,7 +202,7 @@ export const useAddStatsToExistingGame = (showErrorModal?: (err: any) => void) =
       return null;
     }
 
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = BACKEND_URL;
     try {
       const response = await authFetch(
         `${backendUrl}/api/stats/add-to-game`,
@@ -269,7 +270,7 @@ export const useCalculateRecords = (showErrorModal?: (err: any) => void) => {
       return false;
     }
 
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = BACKEND_URL;
     try {
       const response = await authFetch(
         `${backendUrl}/api/records/calculate`,

--- a/FE/src/hooks/allFetch.ts
+++ b/FE/src/hooks/allFetch.ts
@@ -2,6 +2,7 @@ import { useFetchTeamByName, useFetchGameById, useFetchSeasonById, useFetchArtic
 import { usePaginatedFetch, PaginationParams, DEFAULT_PAGINATION } from "./usePaginatedFetch";
 import { authFetch } from "./authFetch";
 import { useAuth } from "../context/authContext";
+import { BACKEND_URL } from "../constants/api";
 import { Player, Team, Season, Game, Article, Stats, Award, Records, Application, RegionCode } from "../types/interfaces";
 import { useCallback, useEffect, useState } from "react";
 
@@ -72,7 +73,7 @@ export const useGameStages = (params: GameStagesParams = {}) => {
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
     const { token } = useAuth();
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = BACKEND_URL;
     const paramsKey = JSON.stringify(params);
 
     const fetchStages = useCallback(async () => {

--- a/FE/src/hooks/allPatch.ts
+++ b/FE/src/hooks/allPatch.ts
@@ -14,9 +14,9 @@ import type {
   Award,
   Application,
 } from "../types/interfaces";
+import { BACKEND_URL } from "../constants/api";
 
-const backendUrl =
-  import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+const backendUrl = BACKEND_URL;
 
 /**
  * Hook returning a `patchSeason` fn for updating seasons.

--- a/FE/src/hooks/useCreate.ts
+++ b/FE/src/hooks/useCreate.ts
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { authFetch } from "./authFetch";
 import { useAuth } from "../context/authContext";
+import { BACKEND_URL } from "../constants/api";
 
 /**
  * Generic hook to POST a new resource to `${endpoint}`.
@@ -28,7 +29,7 @@ export const useCreate = <T, U>(endpoint: string) => {
             return null;
         }
 
-        const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+        const backendUrl = BACKEND_URL;
         try {
             const response = await authFetch(
                 `${backendUrl}/api/${endpoint}`,

--- a/FE/src/hooks/useCreatePlayers.ts
+++ b/FE/src/hooks/useCreatePlayers.ts
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { authFetch } from "./authFetch";  
 import { useAuth } from "../context/authContext";
+import { BACKEND_URL } from "../constants/api";
 import type { Player } from "../types/interfaces";
 
 /**
@@ -50,7 +51,7 @@ export function useBatchPlayersByTeamName() {
       return null;
     }
 
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = BACKEND_URL;
     try {
       const response = await authFetch(
         `${backendUrl}/api/players/batch/by-team-name`,

--- a/FE/src/hooks/useDelete.ts
+++ b/FE/src/hooks/useDelete.ts
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { authFetch } from "./authFetch";
 import { useAuth } from "../context/authContext";
+import { BACKEND_URL } from "../constants/api";
 
 /**
  * Generic hook to DELETE a resource at `${endpoint}/{id}`.
@@ -27,7 +28,7 @@ export const useDelete = (endpoint: string) => {
             return null;
         }
 
-        const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+        const backendUrl = BACKEND_URL;
         try {
             const response = await authFetch(
                 `${backendUrl}/api/${endpoint}/${id}`,

--- a/FE/src/hooks/useFetch.ts
+++ b/FE/src/hooks/useFetch.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { authFetch } from "./authFetch";
+import { BACKEND_URL } from "../constants/api";
 import { TriviaPlayer, TriviaTeam, TriviaSeason, GuessResult } from "../types/interfaces";
 
 
@@ -15,7 +16,7 @@ export const useFetch = <T>(endpoint: string) =>
         const [loading, setLoading] = useState<boolean>(true);
     
         // Base URL (from env or fallback)
-        const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+const backendUrl = BACKEND_URL;
     
         // Fetch data on mount or when endpoint changes
         useEffect(() =>
@@ -95,7 +96,7 @@ export const useObjectFetch = <T>(endpoint: string) =>
     const [loading, setLoading] = useState<boolean>(true);
 
     // Base URL
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = BACKEND_URL;
 
     // Fetch on mount / endpoint change
     useEffect(() =>
@@ -140,7 +141,7 @@ export const useTriviaPlayer = (difficulty: 'easy' | 'medium' | 'hard' | 'imposs
   const [error, setError] = useState<string | null>(null);
 
   // Base URL (from env or fallback)
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+  const backendUrl = BACKEND_URL;
 
   const fetchTriviaPlayer = async () => {
     if (!difficulty) {
@@ -192,7 +193,7 @@ export const useTriviaTeam = (difficulty: 'easy' | 'medium' | 'hard' | 'impossib
   const [error, setError] = useState<string | null>(null);
 
   // Base URL (from env or fallback)
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+  const backendUrl = BACKEND_URL;
 
   const fetchTriviaTeam = async () => {
     if (!difficulty) {
@@ -244,7 +245,7 @@ export const useTriviaSeason = (difficulty: 'easy' | 'medium' | 'hard' | 'imposs
   const [error, setError] = useState<string | null>(null);
 
   // Base URL (from env or fallback)
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+  const backendUrl = BACKEND_URL;
 
   const fetchTriviaSeason = async () => {
     if (!difficulty) {
@@ -296,7 +297,7 @@ export const useSubmitTriviaGuess = () => {
   const [error, setError] = useState<string | null>(null);
 
   // Base URL (from env or fallback)
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+  const backendUrl = BACKEND_URL;
 
   const submitGuess = async (
     type: 'player' | 'team' | 'season',

--- a/FE/src/hooks/useLikeArticle.ts
+++ b/FE/src/hooks/useLikeArticle.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useAuth } from '../context/authContext';
 import { authFetch } from './authFetch';
+import { BACKEND_URL } from '../constants/api';
 
 interface UseLikeArticleReturn {
   likeArticle: (articleId: number) => Promise<boolean>;
@@ -10,7 +11,7 @@ interface UseLikeArticleReturn {
   error: string | null;
 }
 
-const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
+const backendUrl = BACKEND_URL;
 
 export function useLikeArticle(): UseLikeArticleReturn {
   const [isLiking, setIsLiking] = useState(false);

--- a/FE/src/hooks/useLikeStatus.ts
+++ b/FE/src/hooks/useLikeStatus.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '../context/authContext';
 import { authFetch } from './authFetch';
+import { BACKEND_URL } from '../constants/api';
 
 interface UseLikeStatusReturn {
   hasLiked: boolean;
@@ -9,7 +10,7 @@ interface UseLikeStatusReturn {
   refetch: () => void;
 }
 
-const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
+const backendUrl = BACKEND_URL;
 
 export function useLikeStatus(articleId: number): UseLikeStatusReturn {
   const [hasLiked, setHasLiked] = useState(false);

--- a/FE/src/hooks/useLogin.ts
+++ b/FE/src/hooks/useLogin.ts
@@ -2,6 +2,7 @@
 import { useState, useRef } from "react";
 import { useAuth } from "../context/authContext";
 import { isMockMode } from "../utils/authStorage";
+import { BACKEND_URL } from "../constants/api";
 
 export function useLogin() {
   const auth = useAuth?.();
@@ -22,7 +23,7 @@ export function useLogin() {
 
     try {
       const res = await fetch(
-        `${import.meta.env.VITE_BACKEND_URL || "http://localhost:3000"}/api/users/login`,
+        `${BACKEND_URL}/api/users/login`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/FE/src/hooks/usePaginatedFetch.ts
+++ b/FE/src/hooks/usePaginatedFetch.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { authFetch } from "./authFetch";
 import { useAuth } from "../context/authContext";
+import { BACKEND_URL } from "../constants/api";
 import type { PaginatedResponse } from "../types/interfaces";
 
 export interface PaginationParams {
@@ -27,7 +28,7 @@ export const usePaginatedFetch = <T>(
     const [error, setError] = useState<string | null>(null);
     const { token } = useAuth();
 
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = BACKEND_URL;
 
     // Stable key so the effect only re-runs when a param value actually changes
     const paramsKey = JSON.stringify(params);

--- a/FE/src/hooks/usePatch.ts
+++ b/FE/src/hooks/usePatch.ts
@@ -2,9 +2,9 @@
 import { useCallback } from "react";
 import { authFetch }   from "./authFetch";
 import { useAuth } from "../context/authContext";
+import { BACKEND_URL } from "../constants/api";
 
-const backendUrl =
-  import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+const backendUrl = BACKEND_URL;
 
 export function usePatch<T = any>(resource: string)
 {

--- a/FE/src/hooks/useSignUp.ts
+++ b/FE/src/hooks/useSignUp.ts
@@ -1,5 +1,6 @@
 // src/hooks/useSignup.ts
 import { useState } from "react";
+import { BACKEND_URL } from "../constants/api";
 
 export function useSignup()
 {
@@ -11,7 +12,7 @@ export function useSignup()
     const clearError = () => setError(null);
 
     // base URL (env or fallback)
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = BACKEND_URL;
 
     // signup function
     async function signup(username: string, password: string, email: string)

--- a/FE/src/hooks/useUsers.ts
+++ b/FE/src/hooks/useUsers.ts
@@ -1,6 +1,7 @@
 // src/hooks/useUsers.ts
 import { useState, useCallback, useEffect } from "react";
 import { authFetch }             from "./authFetch";
+import { BACKEND_URL } from "../constants/api";
 import type { User } from "../types/interfaces";
 import { useAuth } from "../context/authContext";
 import { usePaginatedFetch, PaginationParams, DEFAULT_PAGINATION } from "./usePaginatedFetch";
@@ -14,7 +15,7 @@ export interface UserListParams extends PaginationParams {
 export const useUsers = (params: UserListParams = DEFAULT_PAGINATION) =>
 {
     const { token, isAuthenticated } = useAuth();
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = BACKEND_URL;
 
     const { data, total, totalPages, page, limit, loading, error } =
         usePaginatedFetch<User>("users", params);

--- a/FE/src/hooks/useVectorGraphData.ts
+++ b/FE/src/hooks/useVectorGraphData.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { authFetch } from "./authFetch";
+import { BACKEND_URL } from "../constants/api";
 import type { Player, Season } from "../types/interfaces";
 
 /**
@@ -13,7 +14,7 @@ export const useFetchPlayersWithStats = () => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+  const backendUrl = BACKEND_URL;
 
   useEffect(() => {
     const fetchData = async () => {
@@ -51,7 +52,7 @@ export const useFetchSeasons = () => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+  const backendUrl = BACKEND_URL;
 
   useEffect(() => {
     const fetchData = async () => {

--- a/FE/src/utils/fetchAvatarRoblox.ts
+++ b/FE/src/utils/fetchAvatarRoblox.ts
@@ -1,8 +1,10 @@
+import { BACKEND_URL } from "../constants/api";
+
 export async function getRobloxAvatarUrl(username: string): Promise<string | null>
 {
     try
     {
-        const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+        const backendUrl = BACKEND_URL;
         
         const url = `${backendUrl}/api/roblox/avatar/${encodeURIComponent(username)}`;
         const res = await fetch(url);

--- a/FE/vite.config.ts
+++ b/FE/vite.config.ts
@@ -7,6 +7,10 @@ export default defineConfig(({ mode }) => {
     throw new Error('FATAL: VITE_USE_MSW must not be enabled in production builds.');
   }
 
+  if (mode === 'production' && !process.env.VITE_BACKEND_URL) {
+    throw new Error('FATAL: VITE_BACKEND_URL must be set for production builds.');
+  }
+
   return {
     plugins: [react()],
     server: {


### PR DESCRIPTION
## Summary
- Add `FE/src/constants/api.ts` exporting centralized `BACKEND_URL`
- Fail production Vite builds when `VITE_BACKEND_URL` is unset
- Replace duplicated env fallbacks across auth, fetch hooks, and related components

## Test plan
- [ ] `npm run dev` in FE still resolves API to localhost:3000 by default
- [ ] Production build with `VITE_BACKEND_URL` set succeeds
- [ ] Production build without `VITE_BACKEND_URL` fails at config time
