### PR TITLE
fix: use hidden sourcemaps in production

### DIFF
--- a/FE/vite.config.ts
+++ b/FE/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig(({ mode }) => {
       strictPort: true,
     },
     build: {
-      sourcemap: true,
+      sourcemap: mode === 'production' ? 'hidden' : true,
       chunkSizeWarningLimit: 1000,
       rollupOptions: {
         output: {


### PR DESCRIPTION
## Summary
- Set Vite `sourcemap` to `hidden` in production and `true` in development

## Test plan
- [ ] `npm run dev` builds with source maps
- [ ] `npm run build` produces hidden source maps only
