### PR TITLE
fix: require registration opt-in in production

### DIFF
--- a/BE/.env.example
+++ b/BE/.env.example
@@ -21,6 +21,7 @@ REDIS_DISABLED=true
 
 # Optional — caching is disabled when unset
 # REDIS_URL=redis://localhost:6379
+# Registration: open by default in development; in production set to "true" to enable
 ALLOW_REGISTRATION=true
 CORS_ORIGINS=http://localhost:5173,http://localhost:8080
 VITE_BACKEND_URL=http://localhost:3000

--- a/BE/src/middleware/registrationGate.ts
+++ b/BE/src/middleware/registrationGate.ts
@@ -1,9 +1,17 @@
 import { Request, Response, NextFunction } from "express";
 
 export function requireRegistrationEnabled(req: Request, res: Response, next: NextFunction): void {
-    if (process.env.ALLOW_REGISTRATION === "false") {
+    const isProduction = process.env.NODE_ENV === "production";
+
+    if (isProduction && process.env.ALLOW_REGISTRATION !== "true") {
         res.status(403).json({ error: "Registration is disabled" });
         return;
     }
+
+    if (!isProduction && process.env.ALLOW_REGISTRATION === "false") {
+        res.status(403).json({ error: "Registration is disabled" });
+        return;
+    }
+
     next();
 }


### PR DESCRIPTION
## Summary
- In production, registration is disabled unless `ALLOW_REGISTRATION=true`
- Development keeps current open-by-default behavior (opt-out via `false`)
- Document behavior in `BE/.env.example`

## Test plan
- [ ] Dev signup works with default env
- [ ] Production with unset/false `ALLOW_REGISTRATION` returns 403 on signup
- [ ] Production with `ALLOW_REGISTRATION=true` allows signup
