### PR TITLE
fix: enable SSH host verification in mirror workflow

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -6,11 +6,10 @@ jobs:
         if: github.repository == 'ChristianDenniss/volleyProject'
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
             fetch-depth: 0
         - uses: yesolutions/mirror-action@master
           with:
             REMOTE: 'git@github.com:LuvLate/aaaa.git'
             GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
-            GIT_SSH_NO_VERIFY_HOST: "true"


### PR DESCRIPTION
## Summary
- Remove `GIT_SSH_NO_VERIFY_HOST: true` from mirror workflow
- Bump `actions/checkout` from v3 to v4

## Test plan
- [ ] Mirror workflow runs on push (if applicable to fork)
