### PR TITLE
fix: validate env at boot and derive Postgres SSL from config

### DIFF
--- a/BE/.env.example
+++ b/BE/.env.example
@@ -1,32 +1,42 @@
-# Use "development" for local testing and "production" only in deployment.
-NODE_ENV=development
-PORT=3000
-
-# Local PostgreSQL defaults
-DB_HOST=localhost
-DB_PORT=5432
-DB_USER=postgres
-DB_PASS=password
-DB_NAME=volleyball
-
-# Docker compose only — avoids clashing with a local Postgres on 5432
-DOCKER_DB_PORT=5433
-DOCKER_FE_PORT=5173
-
-# Replace this with a long random value, including during local development.
-JWT_SECRET=replace-with-a-secure-random-secret
-
-# Disable Redis in local Docker (optional; defaults to true in compose)
-REDIS_DISABLED=true
-
-# Optional — caching is disabled when unset
-# REDIS_URL=redis://localhost:6379
-ALLOW_REGISTRATION=true
-CORS_ORIGINS=http://localhost:5173,http://localhost:8080
-VITE_BACKEND_URL=http://localhost:3000
-
-# Optional — comma-separated IPs allowed to hit /api/admin (empty = allow all)
-# ADMIN_IP_ALLOWLIST=127.0.0.1,::1
-
-# Optional — required for Challonge tournament import in the admin portal
-# CHALLONGE_API_KEY=your-challonge-api-key
+# Use "development" for local testing and "production" only in deployment.
+NODE_ENV=development
+PORT=3000
+
+# Local PostgreSQL defaults
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASS=password
+DB_NAME=volleyball
+
+# Optional — remote/managed Postgres (overrides DB_* when set)
+# DATABASE_URL=postgresql://user:pass@host:5432/dbname?sslmode=require
+
+# SSL for Postgres (default false for local). Also enabled when DATABASE_URL contains sslmode=require
+# DB_SSL=true
+# DB_SSL_REJECT_UNAUTHORIZED=false
+
+# Never enable in production — schema changes ship via migrations (see src/migrations)
+# TYPEORM_SYNCHRONIZE=true
+
+# Docker compose only — avoids clashing with a local Postgres on 5432
+DOCKER_DB_PORT=5433
+DOCKER_FE_PORT=5173
+
+# Replace this with a long random value, including during local development.
+JWT_SECRET=replace-with-a-secure-random-secret
+
+# Disable Redis in local Docker (optional; defaults to true in compose)
+REDIS_DISABLED=true
+
+# Optional — caching is disabled when unset
+# REDIS_URL=redis://localhost:6379
+ALLOW_REGISTRATION=true
+CORS_ORIGINS=http://localhost:5173,http://localhost:8080
+VITE_BACKEND_URL=http://localhost:3000
+
+# Optional — comma-separated IPs allowed to hit /api/admin (empty = allow all)
+# ADMIN_IP_ALLOWLIST=127.0.0.1,::1
+
+# Optional — required for Challonge tournament import in the admin portal
+# CHALLONGE_API_KEY=your-challonge-api-key

--- a/BE/create-admin-user.js
+++ b/BE/create-admin-user.js
@@ -4,28 +4,16 @@
 
 import { DataSource } from "typeorm";
 import bcrypt from "bcryptjs";
-import dotenv from "dotenv";
-
-dotenv.config();
+import { getPostgresConnectionOptions } from "./db-config.js";
 
 import { User } from "./src/modules/user/user.entity.js";
 
 const AppDataSource = new DataSource({
     type: "postgres",
-    ...(process.env.DATABASE_URL
-        ? { url: process.env.DATABASE_URL }
-        : {
-            host: process.env.DB_HOST || "localhost",
-            port: Number(process.env.DB_PORT) || 5432,
-            username: process.env.DB_USER || "postgres",
-            password: process.env.DB_PASS || "password",
-            database: process.env.DB_NAME || "volleyball",
-        }
-    ),
+    ...getPostgresConnectionOptions(),
     synchronize: false,
     logging: true,
     entities: [User],
-    ssl: false,
 });
 
 async function createAdminUser() {

--- a/BE/db-config.js
+++ b/BE/db-config.js
@@ -1,0 +1,66 @@
+// Shared Postgres connection helpers for standalone JS scripts.
+import dotenv from "dotenv";
+
+dotenv.config();
+process.env.NODE_ENV ??= "development";
+
+export function validateDbEnv() {
+  const isProd = process.env.NODE_ENV === "production";
+  const hasDatabaseUrl = Boolean(process.env.DATABASE_URL?.trim());
+
+  if (!isProd || hasDatabaseUrl) {
+    return;
+  }
+
+  const missing = [];
+  if (!process.env.DB_HOST?.trim()) missing.push("DB_HOST");
+  if (!process.env.DB_USER?.trim()) missing.push("DB_USER");
+  if (process.env.DB_PASS === undefined || process.env.DB_PASS === "") {
+    missing.push("DB_PASS");
+  }
+  if (!process.env.DB_NAME?.trim()) missing.push("DB_NAME");
+
+  if (missing.length > 0) {
+    console.error(
+      `FATAL: Production requires DATABASE_URL or ${missing.join(", ")}`,
+    );
+    process.exit(1);
+  }
+}
+
+export function resolveDbSsl(
+  databaseUrl,
+  dbSsl,
+  dbSslRejectUnauthorized,
+) {
+  const url = databaseUrl ?? "";
+  const sslEnabled = dbSsl === "true" || /sslmode=require/i.test(url);
+  if (!sslEnabled) {
+    return false;
+  }
+  return { rejectUnauthorized: dbSslRejectUnauthorized !== "false" };
+}
+
+export function getPostgresConnectionOptions() {
+  validateDbEnv();
+
+  const ssl = resolveDbSsl(
+    process.env.DATABASE_URL,
+    process.env.DB_SSL,
+    process.env.DB_SSL_REJECT_UNAUTHORIZED,
+  );
+
+  if (process.env.DATABASE_URL) {
+    return { url: process.env.DATABASE_URL, ssl };
+  }
+
+  const isProd = process.env.NODE_ENV === "production";
+  return {
+    host: process.env.DB_HOST || (isProd ? undefined : "localhost"),
+    port: Number(process.env.DB_PORT) || (isProd ? undefined : 5432),
+    username: process.env.DB_USER || (isProd ? undefined : "postgres"),
+    password: process.env.DB_PASS ?? (isProd ? undefined : "password"),
+    database: process.env.DB_NAME || (isProd ? undefined : "volleyball"),
+    ssl,
+  };
+}

--- a/BE/docker-compose.yml
+++ b/BE/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - .env
     environment:
       - NODE_ENV=${NODE_ENV:-development}
+      # ${DB_PASS:-password} is for local Docker Compose only — set DB_PASS explicitly in production
       - DATABASE_URL=postgresql://${DB_USER:-postgres}:${DB_PASS:-password}@db:5432/${DB_NAME:-volleyball}?sslmode=disable
       - REDIS_DISABLED=${REDIS_DISABLED:-true}
     depends_on:
@@ -18,6 +19,7 @@ services:
   db:
     image: postgres:17-alpine
     environment:
+      # ${DB_PASS:-password} is for local Docker Compose only — set DB_PASS explicitly in production
       - POSTGRES_USER=${DB_USER:-postgres}
       - POSTGRES_PASSWORD=${DB_PASS:-password}
       - POSTGRES_DB=${DB_NAME:-volleyball}

--- a/BE/reset-user-roles.js
+++ b/BE/reset-user-roles.js
@@ -4,9 +4,7 @@
 
 import { existsSync } from "fs";
 import { DataSource, In } from "typeorm";
-import dotenv from "dotenv";
-
-dotenv.config();
+import { getPostgresConnectionOptions } from "./db-config.js";
 
 const userEntityPath = existsSync("./dist/modules/user/user.entity.js")
     ? "./dist/modules/user/user.entity.js"
@@ -16,20 +14,10 @@ const { User } = await import(userEntityPath);
 
 const AppDataSource = new DataSource({
     type: "postgres",
-    ...(process.env.DATABASE_URL
-        ? { url: process.env.DATABASE_URL }
-        : {
-            host: process.env.DB_HOST || "localhost",
-            port: Number(process.env.DB_PORT) || 5432,
-            username: process.env.DB_USER || "postgres",
-            password: process.env.DB_PASS || "password",
-            database: process.env.DB_NAME || "volleyball",
-        }
-    ),
+    ...getPostgresConnectionOptions(),
     synchronize: false,
     logging: false,
     entities: [User],
-    ssl: false,
 });
 
 const ELEVATED_ROLES = ["admin", "superadmin"];

--- a/BE/src/config/env.ts
+++ b/BE/src/config/env.ts
@@ -1,0 +1,110 @@
+import dotenv from "dotenv";
+import { z } from "zod";
+
+dotenv.config();
+
+// Local development is the safe default. Deployments must explicitly set
+// NODE_ENV=production to enable production-only behavior.
+process.env.NODE_ENV ??= "development";
+
+const envSchema = z
+  .object({
+    NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+    PORT: z.coerce.number().int().positive().default(3000),
+    JWT_SECRET: z.string().trim().optional(),
+    DATABASE_URL: z.string().trim().min(1).optional(),
+    DB_HOST: z.string().trim().optional(),
+    DB_PORT: z.coerce.number().int().positive().optional(),
+    DB_USER: z.string().trim().optional(),
+    DB_PASS: z.string().optional(),
+    DB_NAME: z.string().trim().optional(),
+    DB_SSL: z.string().optional(),
+    DB_SSL_REJECT_UNAUTHORIZED: z.string().optional(),
+    TYPEORM_SYNCHRONIZE: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.NODE_ENV !== "production") {
+      return;
+    }
+
+    if (!data.JWT_SECRET) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["JWT_SECRET"],
+        message: "JWT_SECRET is required in production",
+      });
+    }
+
+    const hasDatabaseUrl = Boolean(data.DATABASE_URL);
+    if (hasDatabaseUrl) {
+      return;
+    }
+
+    const missing: string[] = [];
+    if (!data.DB_HOST) missing.push("DB_HOST");
+    if (!data.DB_USER) missing.push("DB_USER");
+    if (data.DB_PASS === undefined || data.DB_PASS === "") missing.push("DB_PASS");
+    if (!data.DB_NAME) missing.push("DB_NAME");
+
+    if (missing.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["DATABASE_URL"],
+        message: `Production requires DATABASE_URL or ${missing.join(", ")}`,
+      });
+    }
+  });
+
+function parseEnv() {
+  const result = envSchema.safeParse(process.env);
+  if (!result.success) {
+    console.error("FATAL: Invalid environment configuration");
+    for (const issue of result.error.issues) {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "env";
+      console.error(`  - ${path}: ${issue.message}`);
+    }
+    process.exit(1);
+  }
+  return result.data;
+}
+
+export const env = parseEnv();
+
+export type Env = z.infer<typeof envSchema>;
+
+export type DbSslConfig = false | { rejectUnauthorized: boolean };
+
+export function resolveDbSsl(
+  databaseUrl: string | undefined,
+  dbSsl: string | undefined,
+  dbSslRejectUnauthorized: string | undefined,
+): DbSslConfig {
+  const url = databaseUrl ?? "";
+  const sslEnabled = dbSsl === "true" || /sslmode=require/i.test(url);
+  if (!sslEnabled) {
+    return false;
+  }
+  return { rejectUnauthorized: dbSslRejectUnauthorized !== "false" };
+}
+
+export function getPostgresConnectionOptions(envConfig: Env = env) {
+  const ssl = resolveDbSsl(
+    envConfig.DATABASE_URL,
+    envConfig.DB_SSL,
+    envConfig.DB_SSL_REJECT_UNAUTHORIZED,
+  );
+
+  if (envConfig.DATABASE_URL) {
+    return { url: envConfig.DATABASE_URL, ssl };
+  }
+
+  const isProd = envConfig.NODE_ENV === "production";
+  return {
+    host: envConfig.DB_HOST ?? (isProd ? undefined : "localhost"),
+    port: envConfig.DB_PORT ?? (isProd ? undefined : 5432),
+    username: envConfig.DB_USER ?? (isProd ? undefined : "postgres"),
+    password: envConfig.DB_PASS ?? (isProd ? undefined : "password"),
+    database: envConfig.DB_NAME ?? (isProd ? undefined : "volleyball"),
+    ssl,
+  };
+}

--- a/BE/src/db/data-source.ts
+++ b/BE/src/db/data-source.ts
@@ -1,8 +1,8 @@
 import "reflect-metadata";
 import { DataSource } from "typeorm";
-import dotenv from "dotenv";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import { env, getPostgresConnectionOptions } from "../config/env.js";
 
 // Get the current file's directory in ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -21,8 +21,6 @@ import { Awards } from "../modules/awards/award.entity.js";
 import { Records } from "../modules/records/records.entity.js";
 import { Application } from "../modules/applications/application.entity.js";
 import { Region } from "../modules/regions/region.entity.js";
-
-dotenv.config();
 
 // Define entities
 const entities = [
@@ -43,27 +41,17 @@ const entities = [
 // Configure AppDataSource
 export const AppDataSource = new DataSource({
     type: "postgres",
-    ...(process.env.DATABASE_URL 
-        ? { url: process.env.DATABASE_URL }
-        : {
-            host: process.env.DB_HOST || "localhost",
-            port: Number(process.env.DB_PORT) || 5432,
-            username: process.env.DB_USER || "postgres",
-            password: process.env.DB_PASS || "password",
-            database: process.env.DB_NAME || "volleyball",
-        }
-    ),
+    ...getPostgresConnectionOptions(env),
     // Never auto-sync from NODE_ENV — opt in explicitly for throwaway local DBs only.
     // Schema changes ship via migrations (see src/migrations).
-    synchronize: process.env.TYPEORM_SYNCHRONIZE === "true",
-    logging: process.env.NODE_ENV === "production" ? ["error"] : ["error", "warn", "migration"],
+    synchronize: env.TYPEORM_SYNCHRONIZE === "true",
+    logging: env.NODE_ENV === "production" ? ["error"] : ["error", "warn", "migration"],
     maxQueryExecutionTime: 1000,
     entities: entities,
     migrations: [join(__dirname, "..", "migrations", "*.{js,ts}")], // src/migrations (or dist/migrations after build)
     migrationsTableName: "migrations", // Explicitly set migrations table name
     migrationsTransactionMode: "each",
     subscribers: [],
-    ssl: false, // Disable SSL by default, let the connection URL handle SSL settings
 });
 
 // Initialize the DataSource

--- a/BE/src/migrations/run-migrations.ts
+++ b/BE/src/migrations/run-migrations.ts
@@ -1,14 +1,7 @@
 import { DataSource } from "typeorm";
-import { config } from "dotenv";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-
-// Load environment variables
-config();
-
-// Default to local development unless the environment explicitly selects
-// production (for example, NODE_ENV=production in the deployment platform).
-process.env.NODE_ENV ??= 'development';
+import { env, getPostgresConnectionOptions } from "../config/env.js";
 
 // Get current directory for ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -17,42 +10,24 @@ const __dirname = dirname(__filename);
 console.log("==========================================");
 console.log("MIGRATION PROCESS STARTING");
 console.log("==========================================");
-console.log("Environment:", process.env.NODE_ENV);
+console.log("Environment:", env.NODE_ENV);
 console.log("Node Version:", process.version);
 console.log("Current Directory:", process.cwd());
 
-// Enforce DATABASE_URL in production
-if (process.env.NODE_ENV === 'production') {
-    if (!process.env.DATABASE_URL) {
-        console.error("DATABASE_URL must be set in production!");
-        process.exit(1);
-    }
-}
-
-if (process.env.DATABASE_URL) {
+if (env.DATABASE_URL) {
     console.log("Using DATABASE_URL (redacted)");
 } else {
     console.log("Using individual DB parameters:");
-    console.log("Database Host:", process.env.DB_HOST);
-    console.log("Database Name:", process.env.DB_NAME);
-    console.log("Database Port:", process.env.DB_PORT);
+    console.log("Database Host:", env.DB_HOST);
+    console.log("Database Name:", env.DB_NAME);
+    console.log("Database Port:", env.DB_PORT);
 }
 console.log("==========================================");
 
 // Initialize the DataSource
 const AppDataSource = new DataSource({
     type: "postgres",
-    ...(process.env.DATABASE_URL
-        ? { url: process.env.DATABASE_URL }
-        : {
-            host: process.env.DB_HOST || (process.env.NODE_ENV !== 'production' ? "localhost" : undefined),
-            port: Number(process.env.DB_PORT) || (process.env.NODE_ENV !== 'production' ? 5432 : undefined),
-            username: process.env.DB_USER || (process.env.NODE_ENV !== 'production' ? "postgres" : undefined),
-            password: process.env.DB_PASS || (process.env.NODE_ENV !== 'production' ? "password" : undefined),
-            database: process.env.DB_NAME || (process.env.NODE_ENV !== 'production' ? "volleyball" : undefined),
-        }
-    ),
-    ssl: false, // Disable SSL by default, let the connection URL handle SSL settings
+    ...getPostgresConnectionOptions(env),
     entities: [join(__dirname, "..", "modules", "**", "*.entity.{js,ts}")],
     migrations: [join(__dirname, "*.{js,ts}")],
     migrationsTransactionMode: "each",
@@ -85,4 +60,4 @@ AppDataSource.initialize()
     .catch((error) => {
         console.error("Error during Data Source initialization:", error);
         process.exit(1);
-    }); 
+    });

--- a/BE/src/server.ts
+++ b/BE/src/server.ts
@@ -1,93 +1,86 @@
-import 'reflect-metadata';
-import { createServer } from 'http';
-import { createTerminus } from '@godaddy/terminus';
-import dotenv from 'dotenv';
-import createApp from './app.js';
-import { AppDataSource, initializeDataSource } from './db/data-source.js';
-import { seedDevData } from './db/seed-dev.js';
-import { errorHandler } from './middleware/errorHandling.js'; // Import error handler
-
-// Load environment variables
-dotenv.config();
-
-// Local development is the safe default. Deployments must explicitly set
-// NODE_ENV=production to enable production-only behavior.
-process.env.NODE_ENV ??= 'development';
-
-const INSECURE_JWT_SECRETS = new Set([
-  'your-super-secret-jwt-key-change-this-in-production',
-  'replace-with-a-secure-random-secret',
-]);
-
-const jwtSecret = process.env.JWT_SECRET?.trim();
-const hasInsecureJwtSecret = !jwtSecret || INSECURE_JWT_SECRETS.has(jwtSecret);
-
-if (process.env.NODE_ENV === 'production' && hasInsecureJwtSecret) {
-  console.error('FATAL: JWT_SECRET environment variable is not set to a secure value.');
-  process.exit(1);
-}
-
-if (hasInsecureJwtSecret) {
-  console.warn('WARNING: JWT_SECRET is using a placeholder value. OK for local development only.');
-}
-
-const PORT = process.env.PORT || 3000; // Default to 3000 to match docker-compose
-
-console.log(
-  `Starting server (${process.env.NODE_ENV}) on port ${PORT}` +
-    (process.env.DATABASE_URL ? ' with DATABASE_URL' : ' without DATABASE_URL')
-);
-
-async function startServer(): Promise<void> {
-  try {
-    // Initialize TypeORM DataSource
-    await initializeDataSource();
-
-    if (process.env.NODE_ENV === 'development') {
-      await seedDevData();
-    }
-
-    const app = createApp();
-
-    // Register global error handler LAST
-    app.use(errorHandler); // Add this line to register the error handler
-
-    const server = createServer(app);
-
-    // Handle server graceful shutdown + liveness/readiness probes
-    createTerminus(server, {
-      signal: 'SIGTERM',
-      healthChecks: {
-        '/health': async () => {
-          if (!AppDataSource.isInitialized) {
-            throw new Error('Database not initialized');
-          }
-          await AppDataSource.query('SELECT 1');
-          return { status: 'ok' };
-        },
-      },
-      onSignal: async () => {
-        // Cleanup logic before shutdown
-        console.log('Server is shutting down');
-        if (AppDataSource.isInitialized) {
-          await AppDataSource.destroy();
-          console.log('Database connections closed');
-        }
-      }
-    });
-
-    server.listen(PORT, () => {
-      console.log(`Server running at http://localhost:${PORT}`);
-    });
-  } catch (error) {
-    console.error('Error during startup:', error);
-    process.exit(1);
-  }
-}
-
-startServer().catch((error) => {
-  console.error('Server startup failed:', error);
-  process.exit(1);
-});
-
-export {}; // Add empty export to ensure this is treated as an ESM module
+import 'reflect-metadata';
+import { createServer } from 'http';
+import { createTerminus } from '@godaddy/terminus';
+import { env } from './config/env.js';
+import createApp from './app.js';
+import { AppDataSource, initializeDataSource } from './db/data-source.js';
+import { seedDevData } from './db/seed-dev.js';
+import { errorHandler } from './middleware/errorHandling.js'; // Import error handler
+
+const INSECURE_JWT_SECRETS = new Set([
+  'your-super-secret-jwt-key-change-this-in-production',
+  'replace-with-a-secure-random-secret',
+]);
+
+const jwtSecret = env.JWT_SECRET?.trim();
+const hasInsecureJwtSecret = !jwtSecret || INSECURE_JWT_SECRETS.has(jwtSecret);
+
+if (env.NODE_ENV === 'production' && hasInsecureJwtSecret) {
+  console.error('FATAL: JWT_SECRET environment variable is not set to a secure value.');
+  process.exit(1);
+}
+
+if (hasInsecureJwtSecret) {
+  console.warn('WARNING: JWT_SECRET is using a placeholder value. OK for local development only.');
+}
+
+const PORT = env.PORT;
+
+console.log(
+  `Starting server (${env.NODE_ENV}) on port ${PORT}` +
+    (env.DATABASE_URL ? ' with DATABASE_URL' : ' without DATABASE_URL')
+);
+
+async function startServer(): Promise<void> {
+  try {
+    // Initialize TypeORM DataSource
+    await initializeDataSource();
+
+    if (env.NODE_ENV === 'development') {
+      await seedDevData();
+    }
+
+    const app = createApp();
+
+    // Register global error handler LAST
+    app.use(errorHandler); // Add this line to register the error handler
+
+    const server = createServer(app);
+
+    // Handle server graceful shutdown + liveness/readiness probes
+    createTerminus(server, {
+      signal: 'SIGTERM',
+      healthChecks: {
+        '/health': async () => {
+          if (!AppDataSource.isInitialized) {
+            throw new Error('Database not initialized');
+          }
+          await AppDataSource.query('SELECT 1');
+          return { status: 'ok' };
+        },
+      },
+      onSignal: async () => {
+        // Cleanup logic before shutdown
+        console.log('Server is shutting down');
+        if (AppDataSource.isInitialized) {
+          await AppDataSource.destroy();
+          console.log('Database connections closed');
+        }
+      }
+    });
+
+    server.listen(PORT, () => {
+      console.log(`Server running at http://localhost:${PORT}`);
+    });
+  } catch (error) {
+    console.error('Error during startup:', error);
+    process.exit(1);
+  }
+}
+
+startServer().catch((error) => {
+  console.error('Server startup failed:', error);
+  process.exit(1);
+});
+
+export {}; // Add empty export to ensure this is treated as an ESM module

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./BE/.env
     environment:
       - NODE_ENV=${NODE_ENV:-development}
+      # ${DB_PASS:-password} is for local Docker Compose only — set DB_PASS explicitly in production
       - DATABASE_URL=postgresql://${DB_USER:-postgres}:${DB_PASS:-password}@db:5432/${DB_NAME:-volleyball}?sslmode=disable
       - REDIS_DISABLED=${REDIS_DISABLED:-true}
     depends_on:
@@ -29,6 +30,7 @@ services:
   db:
     image: postgres:17-alpine
     environment:
+      # ${DB_PASS:-password} is for local Docker Compose only — set DB_PASS explicitly in production
       - POSTGRES_USER=${DB_USER:-postgres}
       - POSTGRES_PASSWORD=${DB_PASS:-password}
       - POSTGRES_DB=${DB_NAME:-volleyball}


### PR DESCRIPTION
## Summary
- Add `BE/src/config/env.ts` to parse and validate environment variables once at boot with Zod; production now requires `JWT_SECRET` and either `DATABASE_URL` or full `DB_*` credentials (no silent `password` fallback).
- Wire `server.ts`, `data-source.ts`, migration runner, and admin scripts through shared Postgres connection helpers with SSL derived from `DB_SSL=true` or `sslmode=require` in `DATABASE_URL`.
- Document `TYPEORM_SYNCHRONIZE`, `DB_SSL`, and Docker Compose password defaults in `.env.example` and compose files.

## Test plan
- [ ] Start backend locally with default `.env` — server boots and connects to Postgres
- [ ] Set `NODE_ENV=production` without `DB_PASS` or `DATABASE_URL` — process exits with validation error
- [ ] Set `DATABASE_URL=...?sslmode=require` or `DB_SSL=true` — SSL connection options are enabled
- [ ] Run `create-admin-user.js` and `reset-user-roles.js` in development — still work with local defaults
- [ ] Confirm `TYPEORM_SYNCHRONIZE` gate on main is unchanged (opt-in only)