### PR TITLE
Fix BE build: orderedTeams implicit any

### DIFF
--- a/BE/src/modules/stats/stat.service.ts
+++ b/BE/src/modules/stats/stat.service.ts
@@ -665,8 +665,10 @@ export class StatService extends CacheableService
                     throw new NotFoundError(`Teams not found in season ${gameData.seasonId}: ${missingTeams.join(', ')}`);
                 }
 
-                const teamsByName = new Map(teams.map(t => [t.name, t]));
-                const orderedTeams = gameData.teamNames.map((name: string) => teamsByName.get(name)!);
+                const teamsByName = new Map(teams.map((t: Teams) => [t.name, t]));
+                const orderedTeams: Teams[] = (gameData.teamNames as string[]).map(
+                    (name: string) => teamsByName.get(name)!
+                );
 
                 // Create game
                 const newGame = new Games();


### PR DESCRIPTION
## Summary
- Annotate `orderedTeams` as `Teams[]` in CSV batch upload so `.map(t => t.id)` type-checks under strict mode
- Root cause: `gameData` is `any`, so `gameData.teamNames.map(...)` widened the result to `any`

## Test plan
- [x] `npm run build` in `BE` succeeds

Made with [Cursor](https://cursor.com)