### PR TITLE
Fix HTTP cache miss for falsy responses

### DIFF
--- a/BE/src/middleware/cache.ts
+++ b/BE/src/middleware/cache.ts
@@ -42,7 +42,7 @@ export function cacheMiddleware(options: CacheMiddlewareOptions = {}) {
       // Try to get cached response
       const cached = await cacheService.get(cacheKey, options.prefix);
       
-      if (cached) {
+      if (cached !== null && cached !== undefined) {
         // Return cached response
         res.json(cached);
         return;


### PR DESCRIPTION
## Summary
- Use null/undefined check in `cacheMiddleware` so `[]`/`0`/`false` are served from cache

## Test plan
- [ ] Cache a GET that returns `[]` and confirm the next request is served from cache
