### PR TITLE
refactor: remaining controllers use next(error)

### DIFF
--- a/BE/src/modules/applications/application.controller.ts
+++ b/BE/src/modules/applications/application.controller.ts
@@ -1,37 +1,26 @@
-import { Request, Response } from "express";
-import { NotFoundError } from "../../errors/NotFoundError.js";
+import { Request, Response, NextFunction } from "express";
 import { ApplicationService } from "./application.service.js";
 
 export class ApplicationController {
     private service = new ApplicationService();
 
-    public getAll = async (_req: Request, res: Response): Promise<void> => {
+    public getAll = async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const applications = await this.service.getAll();
             res.status(200).json(applications);
         } catch (error) {
-            res.status(500).json({
-                message: "Internal server error",
-                error: error instanceof Error ? error.message : "Unknown error",
-            });
+            next(error);
         }
     };
 
-    public updateBySlug = async (req: Request, res: Response): Promise<void> => {
+    public updateBySlug = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { slug } = req.params;
 
         try {
             const updated = await this.service.updateBySlug(slug, req.body);
             res.status(200).json(updated);
         } catch (error) {
-            if (error instanceof NotFoundError) {
-                res.status(404).json({ message: error.message });
-                return;
-            }
-            res.status(500).json({
-                message: "Internal server error",
-                error: error instanceof Error ? error.message : "Unknown error",
-            });
+            next(error);
         }
     };
 }

--- a/BE/src/modules/articles/article.controller.ts
+++ b/BE/src/modules/articles/article.controller.ts
@@ -1,8 +1,5 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { ArticleService, ArticleFilters } from './article.service.js';
-import { MissingFieldError } from '../../errors/MissingFieldError.js';
-import { NotFoundError } from '../../errors/NotFoundError.js';
-import { ConflictError } from '../../errors/ConflictError.js';
 import { parsePagination, toPaginatedResult } from '../../utils/pagination.js';
 
 const ARTICLES_DEFAULT_LIMIT = 10;
@@ -14,10 +11,7 @@ export class ArticleController {
         this.articleService = new ArticleService();
     }
 
-    /**
-     * Create a new article
-     */
-    public createArticle = async (req: Request, res: Response): Promise<void> => {
+    public createArticle = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { title, content, summary, imageUrl } = req.body;
         const userId = req.user?.id;
 
@@ -36,53 +30,33 @@ export class ArticleController {
             );
             res.status(201).json(newArticle);
         } catch (error) {
-            if (error instanceof MissingFieldError || error instanceof NotFoundError) {
-                res.status(400).json({ message: error.message });
-            } else {
-                res.status(500).json({ message: 'Internal server error' });
-            }
+            next(error);
         }
     };
 
-    /**
-     * Get all articles
-     */
-    public getAllArticles = async (req: Request, res: Response): Promise<void> => {
+    public getAllArticles = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const pagination = parsePagination(req.query, ARTICLES_DEFAULT_LIMIT);
             const filters = this.parseFilters(req);
             const [data, total] = await this.articleService.getAllArticles(pagination, filters);
             res.status(200).json(toPaginatedResult(data, total, pagination));
         } catch (error) {
-            console.error('Error fetching articles:', error);
-            res
-                .status(500)
-                .json({ message: 'Internal server error' });
+            next(error);
         }
     };
 
-    /**
-     * Get an article by ID
-     */
-    public getArticleById = async (req: Request, res: Response): Promise<void> => {
+    public getArticleById = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { id } = req.params;
 
         try {
             const article = await this.articleService.getArticleById(Number(id));
             res.status(200).json(article);
         } catch (error) {
-            if (error instanceof MissingFieldError || error instanceof NotFoundError) {
-                res.status(400).json({ message: error.message });
-            } else {
-                res.status(500).json({ message: 'Internal server error' });
-            }
+            next(error);
         }
     };
 
-    /**
-     * Update an article
-     */
-    public updateArticle = async (req: Request, res: Response): Promise<void> => {
+    public updateArticle = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { id } = req.params;
         const { title, content, userId, summary, imageUrl, approved } = req.body;
 
@@ -98,36 +72,22 @@ export class ArticleController {
             );
             res.status(200).json(updatedArticle);
         } catch (error) {
-            if (error instanceof MissingFieldError || error instanceof NotFoundError) {
-                res.status(400).json({ message: error.message });
-            } else {
-                res.status(500).json({ message: 'Internal server error' });
-            }
+            next(error);
         }
     };
 
-    /**
-     * Delete an article
-     */
-    public deleteArticle = async (req: Request, res: Response): Promise<void> => {
+    public deleteArticle = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { id } = req.params;
 
         try {
             await this.articleService.deleteArticle(Number(id));
-            res.status(204).send(); // No content
+            res.status(204).send();
         } catch (error) {
-            if (error instanceof MissingFieldError || error instanceof NotFoundError) {
-                res.status(400).json({ message: error.message });
-            } else {
-                res.status(500).json({ message: 'Internal server error' });
-            }
+            next(error);
         }
     };
 
-    /**
-     * Get all articles by user ID (author)
-     */
-    public getArticlesByAuthorId = async (req: Request, res: Response): Promise<void> => {
+    public getArticlesByAuthorId = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { userId } = req.params;
 
         try {
@@ -135,73 +95,43 @@ export class ArticleController {
             const [data, total] = await this.articleService.getArticlesByUserId(Number(userId), pagination);
             res.status(200).json(toPaginatedResult(data, total, pagination));
         } catch (error) {
-            console.error('Error fetching articles by author:', error);
-            if (error instanceof MissingFieldError || error instanceof NotFoundError) {
-                res.status(400).json({ message: error.message });
-            } else {
-                res.status(500).json({ message: 'Internal server error' });
-            }
+            next(error);
         }
     };
 
-    /**
-     * Like an article
-     */
-    public likeArticle = async (req: Request, res: Response): Promise<void> => {
+    public likeArticle = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { id } = req.params;
-        const userId = (req as any).user?.id; // Get user ID from authenticated request
+        const userId = (req as any).user?.id;
 
         try {
             const updatedArticle = await this.articleService.likeArticle(Number(id), userId);
             res.status(200).json(updatedArticle);
         } catch (error) {
-            if (error instanceof MissingFieldError || error instanceof NotFoundError) {
-                res.status(400).json({ message: error.message });
-            } else if (error instanceof ConflictError) {
-                res.status(409).json({ message: error.message });
-            } else {
-                res.status(500).json({ message: 'Internal server error' });
-            }
+            next(error);
         }
     };
 
-    /**
-     * Unlike an article
-     */
-    public unlikeArticle = async (req: Request, res: Response): Promise<void> => {
+    public unlikeArticle = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { id } = req.params;
-        const userId = (req as any).user?.id; // Get user ID from authenticated request
+        const userId = (req as any).user?.id;
 
         try {
             const updatedArticle = await this.articleService.unlikeArticle(Number(id), userId);
             res.status(200).json(updatedArticle);
         } catch (error) {
-            if (error instanceof MissingFieldError || error instanceof NotFoundError) {
-                res.status(400).json({ message: error.message });
-            } else if (error instanceof ConflictError) {
-                res.status(409).json({ message: error.message });
-            } else {
-                res.status(500).json({ message: 'Internal server error' });
-            }
+            next(error);
         }
     };
 
-    /**
-     * Check if current user has liked an article
-     */
-    public checkUserLikeStatus = async (req: Request, res: Response): Promise<void> => {
+    public checkUserLikeStatus = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { id } = req.params;
-        const userId = (req as any).user?.id; // Get user ID from authenticated request
+        const userId = (req as any).user?.id;
 
         try {
             const hasLiked = await this.articleService.hasUserLikedArticle(Number(id), userId);
             res.status(200).json({ hasLiked });
         } catch (error) {
-            if (error instanceof MissingFieldError || error instanceof NotFoundError) {
-                res.status(400).json({ message: error.message });
-            } else {
-                res.status(500).json({ message: 'Internal server error' });
-            }
+            next(error);
         }
     };
 

--- a/BE/src/modules/awards/award.controller.ts
+++ b/BE/src/modules/awards/award.controller.ts
@@ -1,6 +1,4 @@
-import { Request, Response } from 'express';
-import { MissingFieldError } from '../../errors/MissingFieldError.js';
-import { NotFoundError } from '../../errors/NotFoundError.js';
+import { Request, Response, NextFunction } from 'express';
 import { AwardService, AwardFilters, AWARD_SORT_FIELDS, AWARD_DEFAULT_SORT } from './award.service.js';
 import { CreateAwardDto, CreateMultipleAwardsDto, UpdateAwardDto } from './awards.schema.js';
 import { parsePagination, parseSort, toPaginatedResult } from '../../utils/pagination.js';
@@ -18,52 +16,27 @@ export class AwardController {
         this.regionService = new RegionService();
     }
 
-    // Create a new award
-    createAward = async (req: Request, res: Response): Promise<void> => {
+    createAward = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const awardData: CreateAwardDto = req.body;
             const savedAward = await this.awardService.createAward(awardData);
-            
             res.status(201).json(savedAward);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to create award";
-            
-            if (errorMessage.includes("required") || 
-                errorMessage.includes("not found") || 
-                errorMessage.includes("already in use") ||
-                errorMessage.includes("must be")) {
-                res.status(400).json({ error: errorMessage });
-            } else {
-                console.error("Error creating award:", error);
-                res.status(500).json({ error: "Failed to create award" });
-            }
+            next(error);
         }
     };
 
-    // Create multiple awards
-    createMultipleAwards = async (req: Request, res: Response): Promise<void> => {
+    createMultipleAwards = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const awardsData: CreateMultipleAwardsDto = req.body;
             const savedAwards = await this.awardService.createMultipleAwards(awardsData);
-            
             res.status(201).json(savedAwards);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to create multiple awards";
-            
-            if (errorMessage.includes("required") || 
-                errorMessage.includes("not found") || 
-                errorMessage.includes("already in use") ||
-                errorMessage.includes("must be")) {
-                res.status(400).json({ error: errorMessage });
-            } else {
-                console.error("Error creating multiple awards:", error);
-                res.status(500).json({ error: "Failed to create multiple awards" });
-            }
+            next(error);
         }
     };
 
-    // Get all awards
-    getAwards = async (req: Request, res: Response): Promise<void> => {
+    getAwards = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const pagination = parsePagination(req.query, AWARDS_DEFAULT_LIMIT);
             const sort = parseSort(req.query, AWARD_SORT_FIELDS, AWARD_DEFAULT_SORT);
@@ -71,13 +44,11 @@ export class AwardController {
             const [data, total] = await this.awardService.findAllAwards(pagination, filters, sort);
             res.json(toPaginatedResult(data, total, pagination));
         } catch (error) {
-            console.error("Error fetching awards:", error);
-            res.status(500).json({ error: "Failed to fetch awards" });
+            next(error);
         }
     };
 
-    // Get all awards without relations / minimal data
-    getSkinnyAwards = async (req: Request, res: Response): Promise<void> => {
+    getSkinnyAwards = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const pagination = parsePagination(req.query, AWARDS_DEFAULT_LIMIT);
             const sort = parseSort(req.query, AWARD_SORT_FIELDS, AWARD_DEFAULT_SORT);
@@ -85,8 +56,7 @@ export class AwardController {
             const [data, total] = await this.awardService.findSkinnyAllAwards(pagination, filters, sort);
             res.json(toPaginatedResult(data, total, pagination));
         } catch (error) {
-            console.error("Error fetching awards without player-team relations:", error);
-            res.status(500).json({ error: "Failed to fetch awards without player-team relations" });
+            next(error);
         }
     };
 
@@ -102,108 +72,63 @@ export class AwardController {
         };
     }
 
-    // Get award by ID
-    getAwardById = async (req: Request, res: Response): Promise<void> => {
+    getAwardById = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const { id } = req.params;
             const award = await this.awardService.findAwardById(parseInt(id));
             res.json(award);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to fetch award";
-            
-            if (errorMessage.includes("not found")) {
-                res.status(404).json({ error: errorMessage });
-            } else {
-                console.error("Error fetching award by ID:", error);
-                res.status(500).json({ error: "Failed to fetch award" });
-            }
+            next(error);
         }
     };
 
-    // Get awards by type
-    getAwardsByType = async (req: Request, res: Response): Promise<void> => {
+    getAwardsByType = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const { type } = req.params;
             const pagination = parsePagination(req.query, AWARDS_DEFAULT_LIMIT);
             const [data, total] = await this.awardService.findAwardsByType(type, pagination);
             res.json(toPaginatedResult(data, total, pagination));
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to fetch awards by type";
-            
-            if (errorMessage.includes("not found")) {
-                res.status(404).json({ error: errorMessage });
-            } else {
-                console.error("Error fetching awards by type:", error);
-                res.status(500).json({ error: "Failed to fetch awards by type" });
-            }
+            next(error);
         }
     };
 
-    // Get awards by season
-    getAwardsBySeason = async (req: Request, res: Response): Promise<void> => {
+    getAwardsBySeason = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const { seasonNumber } = req.params;
             const pagination = parsePagination(req.query, AWARDS_DEFAULT_LIMIT);
             const [data, total] = await this.awardService.findAwardsBySeason(parseInt(seasonNumber), pagination);
             res.json(toPaginatedResult(data, total, pagination));
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to fetch awards by season";
-            
-            if (errorMessage.includes("not found")) {
-                res.status(404).json({ error: errorMessage });
-            } else {
-                console.error("Error fetching awards by season:", error);
-                res.status(500).json({ error: "Failed to fetch awards by season" });
-            }
+            next(error);
         }
     };
 
-    // Update an award
-    updateAward = async (req: Request, res: Response): Promise<void> => {
+    updateAward = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const { id } = req.params;
-            const awardData: UpdateAwardDto = req.body;  // Don't add ID to payload
+            const awardData: UpdateAwardDto = req.body;
             const updatedAward = await this.awardService.updateAward(parseInt(id), awardData);
             res.json(updatedAward);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to update award";
-            
-            if (errorMessage.includes("not found")) {
-                res.status(404).json({ error: errorMessage });
-            } else if (errorMessage.includes("required") || 
-                      errorMessage.includes("already in use") ||
-                      errorMessage.includes("must be")) {
-                res.status(400).json({ error: errorMessage });
-            } else {
-                console.error("Error updating award:", error);
-                res.status(500).json({ error: "Failed to update award" });
-            }
+            next(error);
         }
     };
 
-    // Delete an award
-    deleteAward = async (req: Request, res: Response): Promise<void> => {
+    deleteAward = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const { id } = req.params;
             await this.awardService.removeAward(parseInt(id));
             res.status(204).send();
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to delete award";
-            
-            if (errorMessage.includes("not found")) {
-                res.status(404).json({ error: errorMessage });
-            } else {
-                console.error("Error deleting award:", error);
-                res.status(500).json({ error: "Failed to delete award" });
-            }
+            next(error);
         }
     };
 
-    // Create award with player name
-    createAwardWithPlayerNames = async (req: Request, res: Response): Promise<void> => {
+    createAwardWithPlayerNames = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const { description, type, seasonId, playerName, imageUrl } = req.body;
-            
+
             if (!description || !type || !seasonId || !playerName) {
                 res.status(400).json({ error: 'Missing required fields' });
                 return;
@@ -216,28 +141,14 @@ export class AwardController {
                 playerName,
                 imageUrl
             );
-            
+
             res.status(201).json(savedAward);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to create award";
-            
-            if (errorMessage.includes("required") || 
-                errorMessage.includes("not found") || 
-                errorMessage.includes("already in use") ||
-                errorMessage.includes("must be")) {
-                res.status(400).json({ error: errorMessage });
-            } else {
-                console.error("Error creating award with player names:", error);
-                res.status(500).json({ error: errorMessage });
-            }
+            next(error);
         }
     };
-    /**
-     * Get all awards for a specific player
-     * @param req - Express request object
-     * @param res - Express response object
-     */
-    getAwardsByPlayerId = async (req: Request, res: Response): Promise<void> => {
+
+    getAwardsByPlayerId = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const playerId = parseInt(req.params.playerId);
 
@@ -250,12 +161,7 @@ export class AwardController {
             const [data, total] = await this.awardService.getAwardsByPlayerId(playerId, pagination);
             res.json(toPaginatedResult(data, total, pagination));
         } catch (error) {
-            if (error instanceof NotFoundError) {
-                res.status(404).json({ error: error.message });
-            } else {
-                console.error('Error getting awards by player ID:', error);
-                res.status(500).json({ error: 'Internal server error' });
-            }
+            next(error);
         }
-    }
-} 
+    };
+}

--- a/BE/src/modules/regions/region.controller.ts
+++ b/BE/src/modules/regions/region.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { RegionService } from './region.service.js';
 
 export class RegionController {
@@ -8,13 +8,12 @@ export class RegionController {
         this.regionService = new RegionService();
     }
 
-    getAllRegions = async (_req: Request, res: Response): Promise<void> => {
+    getAllRegions = async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const regions = await this.regionService.getAllRegions();
             res.status(200).json(regions);
         } catch (error) {
-            console.error('Error fetching regions:', error);
-            res.status(500).json({ error: 'Failed to fetch regions' });
+            next(error);
         }
     };
 }

--- a/BE/src/modules/roblox/roblox.controller.ts
+++ b/BE/src/modules/roblox/roblox.controller.ts
@@ -1,14 +1,13 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 
 export class RobloxController
 {
-    async getAvatarByUsername(req: Request, res: Response): Promise<void>
+    getAvatarByUsername = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
     {
         try
         {
             const username = req.params.username;
 
-            // Step 1: Get userId from username
             const userRes = await fetch('https://users.roblox.com/v1/usernames/users', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -24,7 +23,6 @@ export class RobloxController
                 return;
             }
 
-            // Step 2: Get imageUrl from avatar thumbnail API
             const thumbRes = await fetch(
                 `https://thumbnails.roblox.com/v1/users/avatar?userIds=${userId}&size=720x720&format=Png&isCircular=false`
             );
@@ -34,18 +32,16 @@ export class RobloxController
 
             if (!imageUrl)
             {
-                res.status(500).json({ error: 'Image URL not available.' });
+                res.status(404).json({ error: 'Image URL not available.' });
                 return;
             }
 
-            // Ensure the URL is properly formatted
             const finalUrl = imageUrl.startsWith('https://') ? imageUrl : `https://${imageUrl}`;
             res.json({ avatarUrl: finalUrl });
         }
         catch (error)
         {
-            console.error('Failed to fetch avatar:', error);
-            res.status(500).json({ error: 'Internal server error.' });
+            next(error);
         }
     }
 }

--- a/BE/src/modules/seasons/season.controller.ts
+++ b/BE/src/modules/seasons/season.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { SeasonService, SeasonFilters } from "./season.service.js";
 import { parsePagination, toPaginatedResult } from "../../utils/pagination.js";
 import { parseRegionQuery } from "../../utils/regionQuery.js";
@@ -18,10 +18,7 @@ export class SeasonController
         this.regionService = new RegionService();
     }
 
-    /* ------------------------------------------------------------
-       Create a new season
-    ------------------------------------------------------------ */
-    createSeason = async (req: Request, res: Response): Promise<void> =>
+    createSeason = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
     {
         try
         {
@@ -29,7 +26,7 @@ export class SeasonController
                 seasonNumber,
                 startDate,
                 endDate,
-                theme,        
+                theme,
                 image,
                 regionId,
                 region,
@@ -47,98 +44,58 @@ export class SeasonController
 
             res.status(201).json(savedSeason);
         }
-        catch (error: unknown)
+        catch (error)
         {
-            this.handleError(error, res, "creating");
+            next(error);
         }
     };
 
-    /* ------------------------------------------------------------
-       Get all seasons
-    ------------------------------------------------------------ */
-    getAllSeasons = async (req: Request, res: Response): Promise<void> =>
+    getAllSeasons = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
     {
         try
         {
-            console.log('Attempting to fetch all seasons...');
             const pagination = parsePagination(req.query, SEASONS_DEFAULT_LIMIT);
             const filters = await this.parseFilters(req);
             const [data, total] = await this.seasonService.getAllSeasons(pagination, filters);
-            console.log(`Successfully fetched ${data.length} seasons`);
             res.status(200).json(toPaginatedResult(data, total, pagination));
         }
-        catch (error: unknown)
+        catch (error)
         {
-            console.error('Error in getAllSeasons:', {
-                error: error instanceof Error ? {
-                    message: error.message,
-                    stack: error.stack,
-                    name: error.name
-                } : error,
-                timestamp: new Date().toISOString()
-            });
-            this.handleError(error, res, "fetching seasons");
+            next(error);
         }
     };
 
-
-    getSkinnyAllSeasons = async (req: Request, res: Response): Promise<void> =>
-        {
-            try
-            {
-                console.log('Attempting to fetch all seasons...');
-                const pagination = parsePagination(req.query, SEASONS_DEFAULT_LIMIT);
-                const filters = await this.parseFilters(req);
-                const [data, total] = await this.seasonService.getSkinnyAllSeasons(pagination, filters);
-                console.log(`Successfully fetched ${data.length} seasons`);
-                res.status(200).json(toPaginatedResult(data, total, pagination));
-            }
-            catch (error: unknown)
-            {
-                console.error('Error in getSkinnyAllSeasons:', {
-                    error: error instanceof Error ? {
-                        message: error.message,
-                        stack: error.stack,
-                        name: error.name
-                    } : error,
-                    timestamp: new Date().toISOString()
-                });
-                this.handleError(error, res, "fetching seasons");
-            }
-        };
-
-
-    getMediumAllSeasons = async (req: Request, res: Response): Promise<void> =>
+    getSkinnyAllSeasons = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
     {
         try
         {
-            console.log('Attempting to fetch all seasons...');
+            const pagination = parsePagination(req.query, SEASONS_DEFAULT_LIMIT);
+            const filters = await this.parseFilters(req);
+            const [data, total] = await this.seasonService.getSkinnyAllSeasons(pagination, filters);
+            res.status(200).json(toPaginatedResult(data, total, pagination));
+        }
+        catch (error)
+        {
+            next(error);
+        }
+    };
+
+    getMediumAllSeasons = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
+    {
+        try
+        {
             const pagination = parsePagination(req.query, SEASONS_DEFAULT_LIMIT);
             const filters = await this.parseFilters(req);
             const [data, total] = await this.seasonService.getMediumAllSeasons(pagination, filters);
-            console.log(`Successfully fetched ${data.length} seasons`);
             res.status(200).json(toPaginatedResult(data, total, pagination));
         }
-        catch (error: unknown)
+        catch (error)
         {
-            console.error('Error in getMediumAllSeasons:',
-            {
-                error: error instanceof Error ?
-                {
-                    message: error.message,
-                    stack: error.stack,
-                    name: error.name
-                } : error,
-                    timestamp: new Date().toISOString()
-            });
-                this.handleError(error, res, "fetching seasons");
-            }
+            next(error);
+        }
     };
 
-    /* ------------------------------------------------------------
-       Get season by ID
-    ------------------------------------------------------------ */
-    getSeasonById = async (req: Request, res: Response): Promise<void> =>
+    getSeasonById = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
     {
         try
         {
@@ -146,16 +103,13 @@ export class SeasonController
             const season  = await this.seasonService.getSeasonById(id);
             res.status(200).json(season);
         }
-        catch (error: unknown)
+        catch (error)
         {
-            this.handleError(error, res, "fetching season");
+            next(error);
         }
     };
 
-    /* ------------------------------------------------------------
-       Update a season
-    ------------------------------------------------------------ */
-    updateSeason = async (req: Request, res: Response): Promise<void> =>
+    updateSeason = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
     {
         try
         {
@@ -164,8 +118,8 @@ export class SeasonController
                 seasonNumber,
                 startDate,
                 endDate,
-                theme,       // NEW – may be supplied
-                image        // NEW – may be supplied
+                theme,
+                image
             } = req.body;
 
             const updated = await this.seasonService.updateSeason(
@@ -179,16 +133,13 @@ export class SeasonController
 
             res.status(200).json(updated);
         }
-        catch (error: unknown)
+        catch (error)
         {
-            this.handleError(error, res, "updating season");
+            next(error);
         }
     };
 
-    /* ------------------------------------------------------------
-       Delete a season
-    ------------------------------------------------------------ */
-    deleteSeason = async (req: Request, res: Response): Promise<void> =>
+    deleteSeason = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
     {
         try
         {
@@ -196,9 +147,9 @@ export class SeasonController
             await this.seasonService.deleteSeason(id);
             res.status(204).send();
         }
-        catch (error: unknown)
+        catch (error)
         {
-            this.handleError(error, res, "deleting season");
+            next(error);
         }
     };
 
@@ -206,35 +157,5 @@ export class SeasonController
         const regionFilter = parseRegionQuery(req.query as Record<string, unknown>);
         const regionId = await this.regionService.resolveRegionId(regionFilter);
         return { regionId };
-    }
-
-    /* ------------------------------------------------------------
-       Shared error-handling helper
-    ------------------------------------------------------------ */
-    private handleError(
-        error: unknown,
-        res: Response,
-        action: string
-    ): void
-    {
-        const message =
-            error instanceof Error ? error.message : `Failed while ${action}`;
-
-        if (
-            message.includes("required") ||
-            message.includes("already exists") ||
-            message.includes("out of bounds") ||
-            message.includes("Cannot delete") ||
-            message.includes("not found") ||
-            message.includes("must be between")
-        )
-        {
-            res.status(400).json({ error: message });
-        }
-        else
-        {
-            console.error(`Error ${action}:`, error);
-            res.status(500).json({ error: `Failed while ${action}` });
-        }
     }
 }

--- a/BE/src/modules/trivia/trivia.controller.ts
+++ b/BE/src/modules/trivia/trivia.controller.ts
@@ -1,10 +1,8 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { TriviaService } from './trivia.service.js';
-import { 
-    DifficultyQuerySchema, 
+import {
+    DifficultyQuerySchema,
     GuessRequestSchema,
-    type DifficultyQuery,
-    type GuessRequest
 } from './trivia.schema.js';
 
 export class TriviaController {
@@ -14,18 +12,12 @@ export class TriviaController {
         this.triviaService = new TriviaService();
     }
 
-    /**
-     * Get a random trivia player with all relations
-     */
-    getRandomTriviaPlayer = async (req: Request, res: Response): Promise<void> => {
-        
+    getRandomTriviaPlayer = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
-            // Validate query parameters
             const queryResult = DifficultyQuerySchema.safeParse(req.query);
-            
+
             if (!queryResult.success) {
-                console.error('❌ [TriviaController] Query validation failed:', queryResult.error.errors);
-                res.status(400).json({ 
+                res.status(400).json({
                     error: 'Invalid difficulty parameter',
                     details: queryResult.error.errors
                 });
@@ -33,34 +25,20 @@ export class TriviaController {
             }
 
             const { difficulty } = queryResult.data;
-            
             const triviaPlayer = await this.triviaService.getRandomTriviaPlayer(difficulty);
-            
+
             res.json(triviaPlayer);
         } catch (error) {
-            console.error('❌ [TriviaController] Error getting random trivia player:', error);
-            console.error('❌ [TriviaController] Error details:', {
-                message: error instanceof Error ? error.message : 'Unknown error',
-                stack: error instanceof Error ? error.stack : undefined
-            });
-            res.status(500).json({ 
-                error: 'Failed to get trivia player' 
-            });
+            next(error);
         }
     };
 
-    /**
-     * Get a random trivia team with all relations
-     */
-    getRandomTriviaTeam = async (req: Request, res: Response): Promise<void> => {
-        
+    getRandomTriviaTeam = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
-            // Validate query parameters
             const queryResult = DifficultyQuerySchema.safeParse(req.query);
-            
+
             if (!queryResult.success) {
-                console.error('❌ [TriviaController] Query validation failed:', queryResult.error.errors);
-                res.status(400).json({ 
+                res.status(400).json({
                     error: 'Invalid difficulty parameter',
                     details: queryResult.error.errors
                 });
@@ -68,34 +46,20 @@ export class TriviaController {
             }
 
             const { difficulty } = queryResult.data;
-            
             const triviaTeam = await this.triviaService.getRandomTriviaTeam(difficulty);
-            
+
             res.json(triviaTeam);
         } catch (error) {
-            console.error('❌ [TriviaController] Error getting random trivia team:', error);
-            console.error('❌ [TriviaController] Error details:', {
-                message: error instanceof Error ? error.message : 'Unknown error',
-                stack: error instanceof Error ? error.stack : undefined
-            });
-            res.status(500).json({ 
-                error: 'Failed to get trivia team' 
-            });
+            next(error);
         }
     };
 
-    /**
-     * Get a random trivia season with all relations
-     */
-    getRandomTriviaSeason = async (req: Request, res: Response): Promise<void> => {
-        
+    getRandomTriviaSeason = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
-            // Validate query parameters
             const queryResult = DifficultyQuerySchema.safeParse(req.query);
-            
+
             if (!queryResult.success) {
-                console.error('❌ [TriviaController] Query validation failed:', queryResult.error.errors);
-                res.status(400).json({ 
+                res.status(400).json({
                     error: 'Invalid difficulty parameter',
                     details: queryResult.error.errors
                 });
@@ -103,53 +67,31 @@ export class TriviaController {
             }
 
             const { difficulty } = queryResult.data;
-            
             const triviaSeason = await this.triviaService.getRandomTriviaSeason(difficulty);
-            
+
             res.json(triviaSeason);
         } catch (error) {
-            console.error('❌ [TriviaController] Error getting random trivia season:', error);
-            console.error('❌ [TriviaController] Error details:', {
-                message: error instanceof Error ? error.message : 'Unknown error',
-                stack: error instanceof Error ? error.stack : undefined
-            });
-            res.status(500).json({ 
-                error: 'Failed to get trivia season' 
-            });
+            next(error);
         }
     };
 
-    /**
-     * Validate a user's guess
-     */
-    validateGuess = async (req: Request, res: Response): Promise<void> => {
-        
+    validateGuess = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
-            // Validate request body
             const bodyResult = GuessRequestSchema.safeParse(req.body);
             if (!bodyResult.success) {
-                console.error('❌ [TriviaController] Body validation failed:', bodyResult.error.errors);
                 res.status(400).json({
                     error: 'Invalid request body',
                     details: bodyResult.error.errors
                 });
                 return;
             }
-            
+
             const { type, id, guess } = bodyResult.data;
-            
             const result = await this.triviaService.validateGuess(type, id, guess);
-            
+
             res.json(result);
         } catch (error) {
-            console.error('❌ [TriviaController] Error validating guess:', error);
-            console.error('❌ [TriviaController] Error details:', {
-                message: error instanceof Error ? error.message : 'Unknown error',
-                stack: error instanceof Error ? error.stack : undefined
-            });
-            res.status(500).json({
-                error: 'Failed to validate guess'
-            });
+            next(error);
         }
     };
-} 
+}

--- a/BE/src/modules/user/__tests__/user.controller.test.ts
+++ b/BE/src/modules/user/__tests__/user.controller.test.ts
@@ -1,12 +1,12 @@
-import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { Request, Response } from 'express';
 import { UserController } from '../user.controller.js';
+import { MissingFieldError } from '../../../errors/MissingFieldError.js';
+import { NotFoundError } from '../../../errors/NotFoundError.js';
+import { UnauthorizedError } from '../../../errors/UnauthorizedError.js';
 
-// Mock data
 const mockUser = {
   id: 1,
   username: 'testuser',
-  email: 'test@example.com', 
+  email: 'test@example.com',
   password: 'hashedpassword',
   role: 'user',
   createdAt: new Date(),
@@ -28,13 +28,12 @@ const mockUsers = [
 
 const mockToken = 'mock.jwt.token';
 
-// Mock the UserService
 jest.mock('../user.service', () => {
   return {
     UserService: jest.fn().mockImplementation(() => {
       return {
         createUser: jest.fn(),
-        getAllUsers: jest.fn(),
+        getPublicUsers: jest.fn(),
         getUserById: jest.fn(),
         authenticateUser: jest.fn(),
         getProfile: jest.fn(),
@@ -49,6 +48,7 @@ describe('UserController', () => {
   let userController;
   let mockRequest;
   let mockResponse;
+  let next;
   let jsonMock;
   let statusMock;
   let sendMock;
@@ -57,12 +57,15 @@ describe('UserController', () => {
     jsonMock = jest.fn().mockReturnThis();
     sendMock = jest.fn().mockReturnThis();
     statusMock = jest.fn().mockReturnValue({ json: jsonMock, send: sendMock, cookie: jest.fn(), clearCookie: jest.fn() });
+    next = jest.fn();
 
     mockRequest = {};
     mockResponse = {
       json: jsonMock,
       status: statusMock,
       send: sendMock,
+      cookie: jest.fn(),
+      clearCookie: jest.fn(),
     };
 
     userController = new UserController();
@@ -74,8 +77,6 @@ describe('UserController', () => {
 
   describe('register', () => {
     it('should register a user and return 201 status', async () => {
-      const { password, ...userWithoutPassword } = mockUser;
-
       mockRequest.body = {
         username: 'testuser',
         email: 'test@example.com',
@@ -83,60 +84,45 @@ describe('UserController', () => {
       };
       userController.userService.createUser.mockResolvedValueOnce(mockUser);
 
-      await userController.register(mockRequest, mockResponse);
+      await userController.register(mockRequest, mockResponse, next);
 
       expect(userController.userService.createUser).toHaveBeenCalledWith('testuser', 'test@example.com', 'password123', 'user');
       expect(statusMock).toHaveBeenCalledWith(201);
       expect(jsonMock).toHaveBeenCalledWith(expect.not.objectContaining({ password: expect.any(String) }));
+      expect(next).not.toHaveBeenCalled();
     });
 
-    it('should handle validation errors with 400 status', async () => {
+    it('should forward validation errors to error handler', async () => {
+      const validationError = new MissingFieldError('Password');
       mockRequest.body = {
         username: 'testuser',
         email: 'test@example.com',
         password: '',
       };
-      userController.userService.createUser.mockRejectedValueOnce(new Error('Password is required'));
+      userController.userService.createUser.mockRejectedValueOnce(validationError);
 
-      await userController.register(mockRequest, mockResponse);
+      await userController.register(mockRequest, mockResponse, next);
 
-      expect(statusMock).toHaveBeenCalledWith(400);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'Password is required' });
+      expect(next).toHaveBeenCalledWith(validationError);
     });
 
-    it('should handle duplicate user errors with 400 status', async () => {
-      mockRequest.body = {
-        username: 'existinguser',
-        email: 'test@example.com',
-        password: 'password123',
-      };
-      userController.userService.createUser.mockRejectedValueOnce(new Error('Username already in use'));
-
-      await userController.register(mockRequest, mockResponse);
-
-      expect(statusMock).toHaveBeenCalledWith(400);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'Username already in use' });
-    });
-
-    it('should handle server errors with 500 status', async () => {
+    it('should forward server errors to error handler', async () => {
+      const serverError = new Error('Database error');
       mockRequest.body = {
         username: 'testuser',
         email: 'test@example.com',
         password: 'password123',
       };
-      userController.userService.createUser.mockRejectedValueOnce(new Error('Database error'));
+      userController.userService.createUser.mockRejectedValueOnce(serverError);
 
-      await userController.register(mockRequest, mockResponse);
+      await userController.register(mockRequest, mockResponse, next);
 
-      expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'Failed to register user' });
+      expect(next).toHaveBeenCalledWith(serverError);
     });
   });
 
   describe('login', () => {
     it('should login a user and return token', async () => {
-      const { password, ...userWithoutPassword } = mockUser;
-
       mockRequest.body = {
         username: 'testuser',
         password: 'password123',
@@ -146,156 +132,121 @@ describe('UserController', () => {
         token: mockToken,
       });
 
-      await userController.login(mockRequest, mockResponse);
+      await userController.login(mockRequest, mockResponse, next);
 
       expect(userController.userService.authenticateUser).toHaveBeenCalledWith('testuser', 'password123');
       expect(jsonMock).toHaveBeenCalledWith({
         user: expect.not.objectContaining({ password: expect.any(String) }),
       });
+      expect(next).not.toHaveBeenCalled();
     });
 
-    it('should handle validation errors with 400 status', async () => {
-      mockRequest.body = {
-        username: 'testuser',
-        password: '',
-      };
-      userController.userService.authenticateUser.mockRejectedValueOnce(new Error('Password is required'));
-
-      await userController.login(mockRequest, mockResponse);
-
-      expect(statusMock).toHaveBeenCalledWith(400);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'Password is required' });
-    });
-
-    it('should handle invalid credentials with 401 status', async () => {
+    it('should forward invalid credentials to error handler', async () => {
+      const authError = new UnauthorizedError('Invalid username or password');
       mockRequest.body = {
         username: 'testuser',
         password: 'wrongpassword',
       };
-      const { UnauthorizedError } = await import('../../../errors/UnauthorizedError.js');
-      userController.userService.authenticateUser.mockRejectedValueOnce(
-        new UnauthorizedError('Invalid username or password')
-      );
+      userController.userService.authenticateUser.mockRejectedValueOnce(authError);
 
-      await userController.login(mockRequest, mockResponse);
+      await userController.login(mockRequest, mockResponse, next);
 
-      expect(statusMock).toHaveBeenCalledWith(401);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'Invalid username or password' });
+      expect(next).toHaveBeenCalledWith(authError);
     });
 
-    it('should handle server errors with 500 status', async () => {
+    it('should forward server errors to error handler', async () => {
+      const serverError = new Error('Database error');
       mockRequest.body = {
         username: 'testuser',
         password: 'password123',
       };
-      userController.userService.authenticateUser.mockRejectedValueOnce(new Error('Database error'));
+      userController.userService.authenticateUser.mockRejectedValueOnce(serverError);
 
-      await userController.login(mockRequest, mockResponse);
+      await userController.login(mockRequest, mockResponse, next);
 
-      expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'Failed to login' });
+      expect(next).toHaveBeenCalledWith(serverError);
     });
   });
 
-  describe('getUsers', () => {
-    it('should return all users without passwords', async () => {
-      const usersWithoutPasswords = mockUsers.map((user) => {
-        const { password, ...userWithoutPassword } = user;
-        return userWithoutPassword;
-      });
+  describe('getPublicUsers', () => {
+    it('should return paginated users', async () => {
+      const usersWithoutPasswords = mockUsers.map(({ password, ...userWithoutPassword }) => userWithoutPassword);
+      mockRequest.query = {};
 
-      userController.userService.getAllUsers.mockResolvedValueOnce(mockUsers);
+      userController.userService.getPublicUsers.mockResolvedValueOnce([usersWithoutPasswords, usersWithoutPasswords.length]);
 
-      await userController.getUsers(mockRequest, mockResponse);
+      await userController.getPublicUsers(mockRequest, mockResponse, next);
 
-      expect(userController.userService.getAllUsers).toHaveBeenCalled();
-      expect(jsonMock).toHaveBeenCalledWith(usersWithoutPasswords);
+      expect(userController.userService.getPublicUsers).toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
     });
 
-    it('should handle server errors with 500 status', async () => {
-      userController.userService.getAllUsers.mockRejectedValueOnce(new Error('Database error'));
+    it('should forward server errors to error handler', async () => {
+      const serverError = new Error('Database error');
+      mockRequest.query = {};
+      userController.userService.getPublicUsers.mockRejectedValueOnce(serverError);
 
-      await userController.getUsers(mockRequest, mockResponse);
+      await userController.getPublicUsers(mockRequest, mockResponse, next);
 
-      expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'Failed to fetch users' });
+      expect(next).toHaveBeenCalledWith(serverError);
     });
   });
 
   describe('getUserById', () => {
-    it('should return a user by id without password', async () => {
-      const { password, ...userWithoutPassword } = mockUser;
-
+    it('should return a user by id', async () => {
       mockRequest.params = { id: '1' };
+      mockRequest.user = { id: 1, username: 'testuser', role: 'admin' };
       userController.userService.getUserById.mockResolvedValueOnce(mockUser);
 
-      await userController.getUserById(mockRequest, mockResponse);
+      await userController.getUserById(mockRequest, mockResponse, next);
 
       expect(userController.userService.getUserById).toHaveBeenCalledWith(1);
-      expect(jsonMock).toHaveBeenCalledWith(expect.not.objectContaining({ password: expect.any(String) }));
+      expect(jsonMock).toHaveBeenCalledWith(mockUser);
+      expect(next).not.toHaveBeenCalled();
     });
 
-    it('should handle not found errors with 404 status', async () => {
+    it('should forward not found errors to error handler', async () => {
+      const notFoundError = new NotFoundError('User not found');
       mockRequest.params = { id: '999' };
-      userController.userService.getUserById.mockRejectedValueOnce(new Error('User not found'));
+      mockRequest.user = { id: 1, username: 'testuser', role: 'admin' };
+      userController.userService.getUserById.mockRejectedValueOnce(notFoundError);
 
-      await userController.getUserById(mockRequest, mockResponse);
+      await userController.getUserById(mockRequest, mockResponse, next);
 
-      expect(statusMock).toHaveBeenCalledWith(404);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'User not found' });
-    });
-
-    it('should handle server errors with 500 status', async () => {
-      mockRequest.params = { id: '1' };
-      userController.userService.getUserById.mockRejectedValueOnce(new Error('Database error'));
-
-      await userController.getUserById(mockRequest, mockResponse);
-
-      expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'Failed to fetch user' });
+      expect(next).toHaveBeenCalledWith(notFoundError);
     });
   });
 
   describe('getProfile', () => {
     it('should return the current user profile without password', async () => {
-      const { password, ...userWithoutPassword } = mockUser;
-
       mockRequest.user = { id: 1, username: 'testuser', role: 'user' };
       userController.userService.getProfile.mockResolvedValueOnce(mockUser);
 
-      await userController.getProfile(mockRequest, mockResponse);
+      await userController.getProfile(mockRequest, mockResponse, next);
 
       expect(userController.userService.getProfile).toHaveBeenCalledWith(1);
       expect(jsonMock).toHaveBeenCalledWith(expect.not.objectContaining({ password: expect.any(String) }));
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('should handle unauthorized errors with 401 status', async () => {
       mockRequest.user = undefined;
 
-      await userController.getProfile(mockRequest, mockResponse);
+      await userController.getProfile(mockRequest, mockResponse, next);
 
       expect(statusMock).toHaveBeenCalledWith(401);
       expect(jsonMock).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(next).not.toHaveBeenCalled();
     });
 
-    it('should handle not found errors with 404 status', async () => {
+    it('should forward not found errors to error handler', async () => {
+      const notFoundError = new NotFoundError('User not found');
       mockRequest.user = { id: 999, username: 'missing', role: 'user' };
-      userController.userService.getProfile.mockRejectedValueOnce(new Error('User not found'));
+      userController.userService.getProfile.mockRejectedValueOnce(notFoundError);
 
-      await userController.getProfile(mockRequest, mockResponse);
+      await userController.getProfile(mockRequest, mockResponse, next);
 
-      expect(statusMock).toHaveBeenCalledWith(404);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'User not found' });
-    });
-
-    it('should handle server errors with 500 status', async () => {
-      mockRequest.user = { id: 1, username: 'testuser', role: 'user' };
-      userController.userService.getProfile.mockRejectedValueOnce(new Error('Database error'));
-
-      await userController.getProfile(mockRequest, mockResponse);
-
-      expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: 'Failed to fetch profile' });
+      expect(next).toHaveBeenCalledWith(notFoundError);
     });
   });
 });

--- a/BE/src/modules/user/user.controller.ts
+++ b/BE/src/modules/user/user.controller.ts
@@ -1,7 +1,6 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { UserService, UserFilters } from './user.service.js';
 import { parsePagination, toPaginatedResult } from '../../utils/pagination.js';
-import { UnauthorizedError } from '../../errors/UnauthorizedError.js';
 import { setAuthCookies, clearAuthCookies } from '../../middleware/authCookie.js';
 
 const USERS_DEFAULT_LIMIT = 10;
@@ -21,7 +20,7 @@ export class UserController {
         };
     }
 
-    register = async (req: Request, res: Response): Promise<void> =>
+    register = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
     {
         try
         {
@@ -40,27 +39,11 @@ export class UserController {
         }
         catch (error)
         {
-            const msg = error instanceof Error ? error.message : "Failed to register user";
-
-            if (
-                msg.includes("required")      ||
-                msg.includes("already")       ||
-                msg.includes("must be")       ||
-                msg.includes("Invalid")       ||
-                msg.includes("Password")
-            )
-            {
-                res.status(400).json({ error: msg });
-            }
-            else
-            {
-                console.error("Error registering user:", error);
-                res.status(500).json({ error: "Failed to register user" });
-            }
+            next(error);
         }
     };
 
-    login = async (req: Request, res: Response): Promise<void> => {
+    login = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const { username, password } = req.body;
             const { user, token } = await this.userService.authenticateUser(username, password);
@@ -71,19 +54,7 @@ export class UserController {
 
             res.json({ user: userWithoutPassword });
         } catch (error) {
-            if (error instanceof UnauthorizedError) {
-                res.status(401).json({ error: "Invalid username or password" });
-                return;
-            }
-
-            const errorMessage = error instanceof Error ? error.message : "Failed to login";
-
-            if (errorMessage.includes("required")) {
-                res.status(400).json({ error: errorMessage });
-            } else {
-                console.error("Error logging in:", error);
-                res.status(500).json({ error: "Failed to login" });
-            }
+            next(error);
         }
     };
 
@@ -92,7 +63,7 @@ export class UserController {
         res.status(204).send();
     };
 
-    changePassword = async (req: Request, res: Response): Promise<void> => {
+    changePassword = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const authUser = req.user;
 
@@ -113,37 +84,22 @@ export class UserController {
             const { password: _, ...userWithoutPassword } = user;
             res.json({ user: userWithoutPassword });
         } catch (error) {
-            if (error instanceof UnauthorizedError) {
-                res.status(401).json({ error: "Invalid username or password" });
-                return;
-            }
-
-            const msg = error instanceof Error ? error.message : "Failed to change password";
-
-            if (msg.includes("Password") || msg.includes("required")) {
-                res.status(400).json({ error: msg });
-            } else if (msg.includes("not found")) {
-                res.status(404).json({ error: msg });
-            } else {
-                console.error("Error changing password:", error);
-                res.status(500).json({ error: "Failed to change password" });
-            }
+            next(error);
         }
     };
 
-    getPublicUsers = async (req: Request, res: Response): Promise<void> => {
+    getPublicUsers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const pagination = parsePagination(req.query, USERS_DEFAULT_LIMIT);
             const filters = this.parseFilters(req);
             const [data, total] = await this.userService.getPublicUsers(pagination, filters);
             res.json(toPaginatedResult(data, total, pagination));
         } catch (error) {
-            console.error("Error fetching users:", error);
-            res.status(500).json({ error: "Failed to fetch users" });
+            next(error);
         }
     };
 
-    getUserById = async (req: Request, res: Response): Promise<void> => {
+    getUserById = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const targetId = parseInt(req.params.id);
             const authUser = req.user;
@@ -163,18 +119,11 @@ export class UserController {
 
             res.json(await this.userService.getUserById(targetId));
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : "Failed to fetch user";
-
-            if (errorMessage.includes("not found")) {
-                res.status(404).json({ error: errorMessage });
-            } else {
-                console.error("Error fetching user by ID:", error);
-                res.status(500).json({ error: "Failed to fetch user" });
-            }
+            next(error);
         }
     };
 
-    getProfile = async (req: Request, res: Response): Promise<void> =>
+    getProfile = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
     {
             try
             {
@@ -194,21 +143,11 @@ export class UserController {
             }
             catch (error)
             {
-                const msg = error instanceof Error ? error.message : "Failed to fetch profile";
-
-                if (msg.includes("not found"))
-                {
-                    res.status(404).json({ error: msg });
-                }
-                else
-                {
-                    console.error("Error fetching user profile:", error);
-                    res.status(500).json({ error: "Failed to fetch profile" });
-                }
+                next(error);
             }
     };
 
-    setRole = async (req: Request, res: Response): Promise<void> =>
+    setRole = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
     {
         try
         {
@@ -230,20 +169,7 @@ export class UserController {
         }
         catch (error)
         {
-            const msg = error instanceof Error ? error.message : "Failed to set role";
-
-            if (msg.includes("Invalid")          ||
-                msg.includes("not found")        ||
-                msg.includes("Unauthorized")     ||
-                msg.includes("privileges"))
-            {
-                res.status(403).json({ error: msg });
-            }
-            else
-            {
-                console.error("Error setting user role:", error);
-                res.status(500).json({ error: "Failed to set role" });
-            }
+            next(error);
         }
     };
 }


### PR DESCRIPTION
## Summary
- Refactor award, article, user, trivia, application, region, season, and roblox controllers to use next(error) instead of inline res.status(500) / instanceof catch chains
- Keep intentional 400/401/403/404 responses for validation, auth, and empty-result cases in handler try blocks
- Update user controller tests to assert next(error) forwarding instead of local 500 shapes

## Test plan
- [x] npx jest src/modules/user/__tests__/user.controller.test.ts
- [ ] Verify error middleware maps CustomError subclasses to expected status codes
