### PR TITLE
refactor: stat create/update use DTO objects

### DIFF
--- a/BE/src/modules/stats/__tests__/stat.controller.test.ts
+++ b/BE/src/modules/stats/__tests__/stat.controller.test.ts
@@ -74,7 +74,7 @@ describe('StatController', () => {
 
             await statController.createStat(mockRequest, mockResponse, next);
 
-            expect(statController.statService.createStat).toHaveBeenCalled();
+            expect(statController.statService.createStat).toHaveBeenCalledWith(mockStat);
             expect(statusMock).toHaveBeenCalledWith(201);
             expect(jsonMock).toHaveBeenCalledWith(mockStat);
             expect(next).not.toHaveBeenCalled();

--- a/BE/src/modules/stats/__tests__/stat.service.test.ts
+++ b/BE/src/modules/stats/__tests__/stat.service.test.ts
@@ -8,6 +8,25 @@ import { NegativeStatError } from '../../../errors/NegativeStatError.js';
 import { NotFoundError } from '../../../errors/NotFoundError.js';
 import { ConflictError } from '../../../errors/ConflictError.js';
 import { DuplicateError } from '../../../errors/DuplicateError.js';
+import { CreateStatDto } from '../stat.schema.js';
+
+const validCreateStatDto: CreateStatDto = {
+    spikingErrors: 0,
+    apeKills: 0,
+    apeAttempts: 0,
+    spikeKills: 0,
+    spikeAttempts: 0,
+    assists: 0,
+    settingErrors: 0,
+    blocks: 0,
+    digs: 0,
+    blockFollows: 0,
+    aces: 0,
+    servingErrors: 0,
+    miscErrors: 0,
+    playerId: 1,
+    gameId: 1,
+};
 
 // Mock TypeORM's Repository
 const mockStatRepository = {
@@ -41,61 +60,55 @@ describe('StatService', () => {
 
     describe('createStat', () => {
         it('should throw MissingFieldError when required fields are missing', async () => {
-            await expect(statService.createStat(
-                undefined as any, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1
-            )).rejects.toThrow(MissingFieldError);
+            await expect(statService.createStat({
+                ...validCreateStatDto,
+                spikingErrors: undefined as any,
+            })).rejects.toThrow(MissingFieldError);
         });
 
         it('should throw NegativeStatError when a negative value is provided', async () => {
-            await expect(statService.createStat(
-                -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1
-            )).rejects.toThrow(NegativeStatError);
+            await expect(statService.createStat({
+                ...validCreateStatDto,
+                spikingErrors: -1,
+            })).rejects.toThrow(NegativeStatError);
         });
 
         it('should throw NotFoundError if player does not exist', async () => {
             mockPlayerRepository.findOne.mockResolvedValue(null);
 
-            await expect(statService.createStat(
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1
-            )).rejects.toThrow(NotFoundError);
+            await expect(statService.createStat(validCreateStatDto)).rejects.toThrow(NotFoundError);
         });
 
         it('should throw NotFoundError if game does not exist', async () => {
-            mockPlayerRepository.findOne.mockResolvedValue({ id: 1, team: { id: 10 } });
+            mockPlayerRepository.findOne.mockResolvedValue({ id: 1, teams: [{ id: 10 }] });
             mockGameRepository.findOne.mockResolvedValue(null);
 
-            await expect(statService.createStat(
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1
-            )).rejects.toThrow(NotFoundError);
+            await expect(statService.createStat(validCreateStatDto)).rejects.toThrow(NotFoundError);
         });
 
         it('should throw ConflictError if player team is not in the game', async () => {
-            mockPlayerRepository.findOne.mockResolvedValue({ id: 1, team: { id: 10 } });
+            mockPlayerRepository.findOne.mockResolvedValue({ id: 1, teams: [{ id: 10 }] });
             mockGameRepository.findOne.mockResolvedValue({
                 id: 1,
                 teams: [{ id: 20 }]
             });
 
-            await expect(statService.createStat(
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1
-            )).rejects.toThrow(ConflictError);
+            await expect(statService.createStat(validCreateStatDto)).rejects.toThrow(ConflictError);
         });
 
         it('should throw DuplicateError if stat already exists for the player and game', async () => {
-            mockPlayerRepository.findOne.mockResolvedValue({ id: 1, team: { id: 10 } });
+            mockPlayerRepository.findOne.mockResolvedValue({ id: 1, teams: [{ id: 10 }] });
             mockGameRepository.findOne.mockResolvedValue({
                 id: 1,
                 teams: [{ id: 10 }]
             });
             mockStatRepository.findOne.mockResolvedValue({ id: 1 });
 
-            await expect(statService.createStat(
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1
-            )).rejects.toThrow(DuplicateError);
+            await expect(statService.createStat(validCreateStatDto)).rejects.toThrow(DuplicateError);
         });
 
         it('should create and return a new stat entry when all validations pass', async () => {
-            mockPlayerRepository.findOne.mockResolvedValue({ id: 1, team: { id: 10 } });
+            mockPlayerRepository.findOne.mockResolvedValue({ id: 1, teams: [{ id: 10 }] });
             mockGameRepository.findOne.mockResolvedValue({
                 id: 1,
                 teams: [{ id: 10 }]
@@ -108,9 +121,7 @@ describe('StatService', () => {
                 game: { id: 1 }
             });
 
-            const result = await statService.createStat(
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1
-            );
+            const result = await statService.createStat(validCreateStatDto);
 
             expect(mockStatRepository.save).toHaveBeenCalled();
             expect(result).toEqual(expect.objectContaining({ id: 1, spikingErrors: 0 }));

--- a/BE/src/modules/stats/stat.controller.ts
+++ b/BE/src/modules/stats/stat.controller.ts
@@ -30,42 +30,7 @@ export class StatController
     {
         try
         {
-            const
-            {
-                spikingErrors,
-                apeKills,
-                apeAttempts,
-                spikeKills,
-                spikeAttempts,
-                assists,
-                settingErrors,
-                blocks,
-                digs,
-                blockFollows,
-                aces,
-                servingErrors,
-                miscErrors,
-                playerId,
-                gameId
-            } = req.body;
-
-            const savedStat = await this.statService.createStat(
-                spikingErrors,
-                apeKills,
-                apeAttempts,
-                spikeKills,
-                spikeAttempts,
-                assists,
-                settingErrors,
-                blocks,
-                digs,
-                blockFollows,
-                aces,
-                servingErrors,
-                miscErrors,
-                playerId,
-                gameId
-            );
+            const savedStat = await this.statService.createStat(req.body);
 
             res.status(201).json(savedStat);
         }
@@ -171,44 +136,7 @@ export class StatController
         try
         {
             const { id } = req.params;
-
-            const
-            {
-                spikingErrors,
-                apeKills,
-                apeAttempts,
-                spikeKills,
-                spikeAttempts,
-                assists,
-                settingErrors,
-                blocks,
-                digs,
-                blockFollows,
-                aces,
-                servingErrors,
-                miscErrors,
-                playerId,
-                gameId
-            } = req.body;
-
-            const updatedStat = await this.statService.updateStat(
-                parseInt(id),
-                spikingErrors,
-                apeKills,
-                apeAttempts,
-                spikeKills,
-                spikeAttempts,
-                assists,
-                settingErrors,
-                blocks,
-                digs,
-                blockFollows,
-                aces,
-                servingErrors,
-                miscErrors,
-                playerId,
-                gameId
-            );
+            const updatedStat = await this.statService.updateStat(parseInt(id), req.body);
 
             res.json(updatedStat);
         }
@@ -280,42 +208,7 @@ export class StatController
     {
         try
         {
-            const
-            {
-                spikingErrors,
-                apeKills,
-                apeAttempts,
-                spikeKills,
-                spikeAttempts,
-                assists,
-                settingErrors,
-                blocks,
-                digs,
-                blockFollows,
-                aces,
-                servingErrors,
-                miscErrors,
-                playerName,
-                gameId
-            } = req.body;
-
-            const savedStat = await this.statService.createStatByUsername(
-                spikingErrors,
-                apeKills,
-                apeAttempts,
-                spikeKills,
-                spikeAttempts,
-                assists,
-                settingErrors,
-                blocks,
-                digs,
-                blockFollows,
-                aces,
-                servingErrors,
-                miscErrors,
-                playerName,
-                gameId
-            );
+            const savedStat = await this.statService.createStatByUsername(req.body);
 
             res.status(201).json(savedStat);
         }

--- a/BE/src/modules/stats/stat.schema.ts
+++ b/BE/src/modules/stats/stat.schema.ts
@@ -30,3 +30,7 @@ export const createStatByNameSchema = createStatSchema
     playerName: z.string().min(1, "Player name is required"),
   });
 
+export type CreateStatDto = z.infer<typeof createStatSchema>;
+export type UpdateStatDto = z.infer<typeof createStatSchema.partial()>;
+export type CreateStatByNameDto = z.infer<typeof createStatByNameSchema>;
+

--- a/BE/src/modules/stats/stat.service.ts
+++ b/BE/src/modules/stats/stat.service.ts
@@ -20,6 +20,7 @@ import {
     buildTeamLeaderboardSql,
     countParamsFrom,
 } from './stat.leaderboard.js';
+import { CreateStatDto, UpdateStatDto, CreateStatByNameDto } from './stat.schema.js';
 
 export interface StatFilters {
     search?: string;
@@ -47,30 +48,26 @@ export class StatService extends CacheableService
     /**
      * Create a new stat entry with validation
      */
-    async createStat(
-        spikingErrors: number,
-        apeKills: number,
-        apeAttempts: number,
-        spikeKills: number,
-        spikeAttempts: number,
-        assists: number,
-
-        // new: setting errors count
-        settingErrors: number,
-
-        blocks: number,
-        digs: number,
-        blockFollows: number,
-        aces: number,
-
-        // new: serving errors count
-        servingErrors: number,
-
-        miscErrors: number,
-        playerId: number,
-        gameId: number
-    ): Promise<Stats>
+    async createStat(dto: CreateStatDto): Promise<Stats>
     {
+        const {
+            spikingErrors,
+            apeKills,
+            apeAttempts,
+            spikeKills,
+            spikeAttempts,
+            assists,
+            settingErrors,
+            blocks,
+            digs,
+            blockFollows,
+            aces,
+            servingErrors,
+            miscErrors,
+            playerId,
+            gameId,
+        } = dto;
+
         // Validation for required fields
         if (spikingErrors === undefined) throw new MissingFieldError("Spiking Errors");
         if (apeKills === undefined)      throw new MissingFieldError("Ape kills");
@@ -174,31 +171,26 @@ export class StatService extends CacheableService
     /**
      * Update a stat entry with validation
      */
-    async updateStat(
-        id: number,
-        spikingErrors?: number,
-        apeKills?: number,
-        apeAttempts?: number,
-        spikeKills?: number,
-        spikeAttempts?: number,
-        assists?: number,
-
-        // new: setting errors
-        settingErrors?: number,
-
-        blocks?: number,
-        digs?: number,
-        blockFollows?: number,
-        aces?: number,
-
-        // new: serving errors
-        servingErrors?: number,
-
-        miscErrors?: number,
-        playerId?: number,
-        gameId?: number
-    ): Promise<Stats>
+    async updateStat(id: number, dto: UpdateStatDto): Promise<Stats>
     {
+        const {
+            spikingErrors,
+            apeKills,
+            apeAttempts,
+            spikeKills,
+            spikeAttempts,
+            assists,
+            settingErrors,
+            blocks,
+            digs,
+            blockFollows,
+            aces,
+            servingErrors,
+            miscErrors,
+            playerId,
+            gameId,
+        } = dto;
+
         if (!id) throw new MissingFieldError("Stat ID");
 
         const stat = await this.statRepository.findOne({
@@ -490,31 +482,26 @@ export class StatService extends CacheableService
     /**
      * Create a new stat entry by player username (instead of ID), with validation
      */
-    async createStatByUsername
-    (
-        spikingErrors: number,
-        apeKills: number,
-        apeAttempts: number,
-        spikeKills: number,
-        spikeAttempts: number,
-        assists: number,
-
-        // new: setting errors count
-        settingErrors: number,
-
-        blocks: number,
-        digs: number,
-        blockFollows: number,
-        aces: number,
-
-        // new: serving errors count
-        servingErrors: number,
-
-        miscErrors: number,
-        username: string,
-        gameId: number
-    ): Promise<Stats>
+    async createStatByUsername(dto: CreateStatByNameDto): Promise<Stats>
     {
+        const {
+            spikingErrors,
+            apeKills,
+            apeAttempts,
+            spikeKills,
+            spikeAttempts,
+            assists,
+            settingErrors,
+            blocks,
+            digs,
+            blockFollows,
+            aces,
+            servingErrors,
+            miscErrors,
+            playerName: username,
+            gameId,
+        } = dto;
+
         // Required-field validation
         if (spikingErrors === undefined)      throw new MissingFieldError("Spiking Errors");
         if (apeKills === undefined)           throw new MissingFieldError("Ape kills");


### PR DESCRIPTION
## Summary
- Replace 15-16 positional parameters on createStat, updateStat, and createStatByUsername with DTO objects inferred from Zod schemas
- Simplify stat.controller to pass validated req.body directly to the service
- Update stat service and controller tests for the new signatures

## Test plan
- [ ] npx jest src/modules/stats/__tests__/stat.service.test.ts
- [ ] npx jest src/modules/stats/__tests__/stat.controller.test.ts
- [ ] POST/PUT /api/stats still accept the same JSON body shape
