### PR TITLE
fix: paginate remaining unbounded list endpoints

### DIFF
--- a/BE/src/modules/applications/application.controller.ts
+++ b/BE/src/modules/applications/application.controller.ts
@@ -1,37 +1,30 @@
-import { Request, Response } from "express";
-import { NotFoundError } from "../../errors/NotFoundError.js";
+import { Request, Response, NextFunction } from "express";
 import { ApplicationService } from "./application.service.js";
+import { parsePagination, toPaginatedResult } from "../../utils/pagination.js";
+
+const APPLICATIONS_DEFAULT_LIMIT = 25;
 
 export class ApplicationController {
     private service = new ApplicationService();
 
-    public getAll = async (_req: Request, res: Response): Promise<void> => {
+    public getAll = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
-            const applications = await this.service.getAll();
-            res.status(200).json(applications);
+            const pagination = parsePagination(req.query, APPLICATIONS_DEFAULT_LIMIT);
+            const [data, total] = await this.service.getAll(pagination);
+            res.status(200).json(toPaginatedResult(data, total, pagination));
         } catch (error) {
-            res.status(500).json({
-                message: "Internal server error",
-                error: error instanceof Error ? error.message : "Unknown error",
-            });
+            next(error);
         }
     };
 
-    public updateBySlug = async (req: Request, res: Response): Promise<void> => {
+    public updateBySlug = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { slug } = req.params;
 
         try {
             const updated = await this.service.updateBySlug(slug, req.body);
             res.status(200).json(updated);
         } catch (error) {
-            if (error instanceof NotFoundError) {
-                res.status(404).json({ message: error.message });
-                return;
-            }
-            res.status(500).json({
-                message: "Internal server error",
-                error: error instanceof Error ? error.message : "Unknown error",
-            });
+            next(error);
         }
     };
 }

--- a/BE/src/modules/applications/application.service.ts
+++ b/BE/src/modules/applications/application.service.ts
@@ -1,5 +1,6 @@
 import { AppDataSource } from "../../db/data-source.js";
 import { NotFoundError } from "../../errors/NotFoundError.js";
+import { PaginationParams } from "../../utils/pagination.js";
 import {
     Application,
     ApplicationStatus,
@@ -102,10 +103,12 @@ export class ApplicationService {
         await this.repository.save(DEFAULT_APPLICATIONS);
     }
 
-    async getAll(): Promise<Application[]> {
+    async getAll(pagination: PaginationParams): Promise<[Application[], number]> {
         await this.ensureSeeded();
-        return this.repository.find({
+        return this.repository.findAndCount({
             order: { sortOrder: "ASC", id: "ASC" },
+            skip: pagination.skip,
+            take: pagination.take,
         });
     }
 

--- a/BE/src/modules/players/player.controller.ts
+++ b/BE/src/modules/players/player.controller.ts
@@ -52,12 +52,17 @@ export class PlayerController {
 
         try
         {
-            const teamNames = await this.playerService.getTeamsByPlayerName(playerName);
+            const pagination = parsePagination(req.query, PLAYERS_DEFAULT_LIMIT);
+            const [data, total] = await this.playerService.getTeamsByPlayerName(playerName, pagination);
+
+            if (total === 0) {
+                res.status(404).json({ message: `No teams found for player ${playerName}` });
+                return;
+            }
 
             res.status(200).json({
-                success: true,
-                playerName: playerName,
-                teams: teamNames
+                ...toPaginatedResult(data, total, pagination),
+                playerName,
             });
         }
         catch (error)

--- a/BE/src/modules/players/player.service.ts
+++ b/BE/src/modules/players/player.service.ts
@@ -97,22 +97,22 @@ export class PlayerService extends CacheableService
     /**
      * Get the list of team names or IDs associated with a player by their name
      */
-    async getTeamsByPlayerName(playerName: string): Promise<string[]> 
+    async getTeamsByPlayerName(playerName: string, pagination: PaginationParams): Promise<[string[], number]> 
     {
         if (!playerName) throw new MissingFieldError("Player name");
 
-        // Find the player by name with related teams
         const player = await this.playerRepository.findOne({
             where: { name: playerName.toLowerCase() },
-            relations: ["teams"], // Fetch related teams
+            relations: ["teams"],
         });
 
         if (!player) throw new NotFoundError(`Player with name "${playerName.toLowerCase()}" not found`);
 
-        // Extract and return the team names or IDs
-        const teamNames = player.teams.map(team => team.name); // If you want names
+        const teamNames = player.teams.map(team => team.name);
+        const total = teamNames.length;
+        const data = teamNames.slice(pagination.skip, pagination.skip + pagination.take);
 
-        return teamNames; // or return teamIds for IDs
+        return [data, total];
     }
 
 

--- a/BE/src/modules/teams/team.controller.ts
+++ b/BE/src/modules/teams/team.controller.ts
@@ -8,6 +8,7 @@ import { RegionService } from '../regions/region.service.js';
 
 const TEAMS_DEFAULT_LIMIT = 10;
 const TEAMS_BY_NAME_DEFAULT_LIMIT = 100;
+const TEAM_PLAYERS_DEFAULT_LIMIT = 25;
 
 export class TeamController {
     private teamService: TeamService;
@@ -45,14 +46,22 @@ export class TeamController {
     getTeamPlayersByName = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const { name } = req.params;
-            const team = await this.teamService.getTeamPlayersByName(name);
+            const pagination = parsePagination(req.query, TEAM_PLAYERS_DEFAULT_LIMIT);
+            const result = await this.teamService.getTeamPlayersByName(name, pagination);
 
-            if (!team) {
+            if (!result) {
                 res.status(404).json({ error: "Team not found" });
                 return;
             }
 
-            res.json(team.players);
+            const [data, total] = result;
+
+            if (total === 0) {
+                res.status(404).json({ message: `No players found for team with name ${name}` });
+                return;
+            }
+
+            res.json(toPaginatedResult(data, total, pagination));
         } catch (error) {
             next(error);
         }
@@ -61,14 +70,15 @@ export class TeamController {
     getTeamPlayers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const { teamId } = req.params;
-            const players = await this.teamService.getTeamPlayers(parseInt(teamId));
+            const pagination = parsePagination(req.query, TEAM_PLAYERS_DEFAULT_LIMIT);
+            const [data, total] = await this.teamService.getTeamPlayers(parseInt(teamId), pagination);
 
-            if (players.length === 0) {
+            if (total === 0) {
                 res.status(404).json({ message: `No players found for team with ID ${teamId}` });
                 return;
             }
 
-            res.json(players);
+            res.json(toPaginatedResult(data, total, pagination));
         } catch (error) {
             next(error);
         }

--- a/BE/src/modules/teams/team.service.ts
+++ b/BE/src/modules/teams/team.service.ts
@@ -179,13 +179,20 @@ export class TeamService {
     /**
      * Get players for a team by name
      */
-    async getTeamPlayersByName(name: string): Promise<Teams | null> {
+    async getTeamPlayersByName(name: string, pagination: PaginationParams): Promise<[Players[], number] | null> {
         const team = await this.teamRepository.findOne({
             where: { name },
-            relations: ["players"],  // Load players for the specific team
         });
 
-        return team;  // Return the team (with players) if found, or null if not found
+        if (!team) {
+            return null;
+        }
+
+        return this.playerRepository.findAndCount({
+            where: { teams: { id: team.id } },
+            skip: pagination.skip,
+            take: pagination.take,
+        });
     }
 
     async getTeamsByName(name: string, pagination: PaginationParams): Promise<[Teams[], number]> {
@@ -244,17 +251,18 @@ export class TeamService {
     /**
      * Get players for a team by team ID
      */
-    async getTeamPlayers(teamId: number): Promise<Players[]> {
-        const team = await this.teamRepository.findOne({
-            where: { id: teamId },
-            relations: ["players"],  // Only load players for the specific team
-        });
+    async getTeamPlayers(teamId: number, pagination: PaginationParams): Promise<[Players[], number]> {
+        const team = await this.teamRepository.findOneBy({ id: teamId });
 
         if (!team) {
-            throw new Error("Team not found");
+            throw new NotFoundError(`Team with ID ${teamId} not found`);
         }
 
-        return team.players; // Return the players associated with the team
+        return this.playerRepository.findAndCount({
+            where: { teams: { id: teamId } },
+            skip: pagination.skip,
+            take: pagination.take,
+        });
     }
 
     /**

--- a/FE/src/hooks/allFetch.ts
+++ b/FE/src/hooks/allFetch.ts
@@ -45,7 +45,7 @@ export const useRecords = (params: RecordListParams = DEFAULT_PAGINATION) => {
     return { ...result, refetch };
 };
 
-export const useApplications = () => useFetch<Application>("applications");
+export const useApplications = () => useFetch<Application>("applications?limit=100");
 
 export const useSkinnyTeams = (params: TeamListParams = DEFAULT_PAGINATION) => usePaginatedFetch<Team>("teams/skinny", params);
 export const useMediumTeams = (params: TeamListParams = DEFAULT_PAGINATION) => usePaginatedFetch<Team>("teams/medium", params);

--- a/FE/src/mocks/handlers.ts
+++ b/FE/src/mocks/handlers.ts
@@ -355,7 +355,7 @@ export const handlers = [
   http.post(api("records/calculate"), () => json({ updated: db.records.length, records: db.records })),
 
   // Applications
-  http.get(api("applications"), () => json(db.applications)),
+  http.get(api("applications"), ({ request }) => json(paginated(db.applications, request))),
   http.patch(api("applications/:slug"), async ({ params, request }) => {
     const body = (await request.json()) as {
       url?: string | null;


### PR DESCRIPTION
## Summary
- Add parsePagination/toPaginatedResult to teams/:teamId/players, teams/name/:name/players, players/teams/:playerName, and GET /api/applications
- Update team and player services to return paginated [data, total] tuples from the database
- Update FE useApplications (limit=100) and MSW handler to consume { data, total, page, limit, totalPages }`n
## Test plan
- [ ] GET /api/teams/:id/players?page=1&limit=10 returns paginated players
- [ ] GET /api/applications returns paginated applications; FE Applications page loads
- [ ] Empty team/player results still return 404 when total is 0
