### PR TITLE
Harden FE Docker image (non-root + healthcheck)

### DIFF
--- a/FE/Dockerfile
+++ b/FE/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build: avoids Nixpacks/Nix (heavy on disk). Use this in Coolify
+﻿# Multi-stage build: avoids Nixpacks/Nix (heavy on disk). Use this in Coolify
 # with Build Pack = Dockerfile, base directory = FE.
 
 FROM node:22-alpine AS build
@@ -19,5 +19,13 @@ FROM nginx:alpine
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 
-EXPOSE 80
+RUN chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/log/nginx /etc/nginx/conf.d \
+    && touch /var/run/nginx.pid \
+    && chown nginx:nginx /var/run/nginx.pid
+USER nginx
+
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/ >/dev/null || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/FE/nginx.conf
+++ b/FE/nginx.conf
@@ -1,5 +1,5 @@
-server {
-    listen 80;
+﻿server {
+    listen 8080;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
## Summary
- Run nginx as `USER nginx` (non-root)
- Listen on port 8080 (unprivileged)
- Add `HEALTHCHECK` against the static root

## Test plan
- [ ] `docker build -t fe ./FE` succeeds
- [ ] Container serves index on `:8080`
- [ ] Update Coolify/port mapping from 80→8080 if needed


Made with [Cursor](https://cursor.com)