### PR TITLE
Add captain, vice captain, and court captain roles

### DIFF
--- a/BE/src/middleware/authValidation.ts
+++ b/BE/src/middleware/authValidation.ts
@@ -3,8 +3,18 @@ import { AppDataSource } from "../db/data-source.js";
 import { UnauthorizedError } from "../errors/UnauthorizedError.js";
 import { User } from "../modules/user/user.entity.js";
 
-export const ALLOWED_JWT_ROLES = ["user", "admin", "superadmin"] as const;
+export const ALLOWED_JWT_ROLES = [
+    "user",
+    "captain",
+    "vice_captain",
+    "court_captain",
+    "admin",
+    "superadmin",
+] as const;
+
 export type AllowedJwtRole = (typeof ALLOWED_JWT_ROLES)[number];
+
+export const STAFF_SITE_ROLES = ["captain", "vice_captain", "court_captain"] as const;
 
 export interface VerifiedJwtUser {
     id: number;
@@ -59,4 +69,26 @@ export async function validateJwtPayload(decoded: jwt.JwtPayload): Promise<Verif
         role: user.role as AllowedJwtRole,
         tokenVersion: user.tokenVersion,
     };
+}
+
+export function signUserToken(user: {
+    id: number;
+    username: string;
+    role: string;
+    tokenVersion: number;
+}): string {
+    return jwt.sign(
+        {
+            id: user.id,
+            username: user.username,
+            role: user.role,
+            tokenVersion: user.tokenVersion,
+        },
+        getJwtSecret(),
+        { expiresIn: "7d" }
+    );
+}
+
+export function normalizeRobloxUsername(username: string): string {
+    return username.trim().toLowerCase();
 }

--- a/BE/src/modules/stats/stat.schema.ts
+++ b/BE/src/modules/stats/stat.schema.ts
@@ -31,6 +31,6 @@ export const createStatByNameSchema = createStatSchema
   });
 
 export type CreateStatDto = z.infer<typeof createStatSchema>;
-export type UpdateStatDto = z.infer<typeof createStatSchema.partial()>;
+export type UpdateStatDto = z.infer<typeof updateStatSchema>;
 export type CreateStatByNameDto = z.infer<typeof createStatByNameSchema>;
 

--- a/BE/src/modules/user/user.controller.ts
+++ b/BE/src/modules/user/user.controller.ts
@@ -1,176 +1,171 @@
-import { Request, Response, NextFunction } from 'express';
-import { UserService, UserFilters } from './user.service.js';
-import { parsePagination, toPaginatedResult } from '../../utils/pagination.js';
-import { setAuthCookies, clearAuthCookies } from '../../middleware/authCookie.js';
-
-const USERS_DEFAULT_LIMIT = 10;
-
-export class UserController {
-    private userService: UserService;
-
-    constructor() {
-        this.userService = new UserService();
-    }
-
-    private parseFilters(req: Request): UserFilters {
-        const { search, role } = req.query;
-        return {
-            search: typeof search === 'string' && search.length > 0 ? search : undefined,
-            role: typeof role === 'string' && role.length > 0 ? role : undefined,
-        };
-    }
-
-    register = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
-    {
-        try
-        {
-            const { username, email, password } = req.body;
-
-            const newUser = await this.userService.createUser(
-                username,
-                email,
-                password,
-                "user"
-            );
-
-            const { password: _p, ...userWithoutPassword } = newUser;
-
-            res.status(201).json(userWithoutPassword);
-        }
-        catch (error)
-        {
-            next(error);
-        }
-    };
-
-    login = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-        try {
-            const { username, password } = req.body;
-            const { user, token } = await this.userService.authenticateUser(username, password);
-
-            const { password: _, ...userWithoutPassword } = user;
-
-            setAuthCookies(res, token);
-
-            res.json({ user: userWithoutPassword });
-        } catch (error) {
-            next(error);
-        }
-    };
-
-    logout = async (_req: Request, res: Response): Promise<void> => {
-        clearAuthCookies(res);
-        res.status(204).send();
-    };
-
-    changePassword = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-        try {
-            const authUser = req.user;
-
-            if (!authUser?.id) {
-                res.status(401).json({ error: "Unauthorized" });
-                return;
-            }
-
-            const { currentPassword, newPassword } = req.body;
-            const { user, token } = await this.userService.changePassword(
-                authUser.id,
-                currentPassword,
-                newPassword
-            );
-
-            setAuthCookies(res, token);
-
-            const { password: _, ...userWithoutPassword } = user;
-            res.json({ user: userWithoutPassword });
-        } catch (error) {
-            next(error);
-        }
-    };
-
-    getPublicUsers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-        try {
-            const pagination = parsePagination(req.query, USERS_DEFAULT_LIMIT);
-            const filters = this.parseFilters(req);
-            const [data, total] = await this.userService.getPublicUsers(pagination, filters);
-            res.json(toPaginatedResult(data, total, pagination));
-        } catch (error) {
-            next(error);
-        }
-    };
-
-    getUserById = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-        try {
-            const targetId = parseInt(req.params.id);
-            const authUser = req.user;
-
-            if (!authUser?.id) {
-                res.status(401).json({ error: "Unauthorized" });
-                return;
-            }
-
-            const isSelf = authUser.id === targetId;
-            const isPrivileged = authUser.role === "admin" || authUser.role === "superadmin";
-
-            if (!isSelf && !isPrivileged) {
-                res.status(403).json({ error: "Forbidden" });
-                return;
-            }
-
-            res.json(await this.userService.getUserById(targetId));
-        } catch (error) {
-            next(error);
-        }
-    };
-
-    getProfile = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
-    {
-            try
-            {
-                const authUser = req.user
-
-                if (!authUser?.id)
-                {
-                    res.status(401).json({ error: "Unauthorized" });
-                    return;
-                }
-
-                const user = await this.userService.getProfile(authUser.id);
-
-                const { password, ...userWithoutPassword } = user;
-
-                res.json(userWithoutPassword);
-            }
-            catch (error)
-            {
-                next(error);
-            }
-    };
-
-    setRole = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
-    {
-        try
-        {
-            const requester = (req as any).user as { id: number; role: "user" | "admin" | "superadmin" };
-
-            const targetId    = parseInt(req.params.id);
-            const desiredRole = req.body.role as "user" | "admin" | "superadmin";
-
-            const updated = await this.userService.changeUserRole(
-                requester,
-                targetId,
-                desiredRole,
-                { ip: req.ip ?? req.socket.remoteAddress }
-            );
-
-            const { password, ...userWithoutPassword } = updated;
-
-            res.json(userWithoutPassword);
-        }
-        catch (error)
-        {
-            next(error);
-        }
-    };
-}
-
+import { Request, Response, NextFunction } from 'express';
+import { UserService, UserFilters } from './user.service.js';
+import { parsePagination, toPaginatedResult } from '../../utils/pagination.js';
+import { setAuthCookies, clearAuthCookies } from '../../middleware/authCookie.js';
+
+const USERS_DEFAULT_LIMIT = 10;
+
+export class UserController {
+    private userService: UserService;
+
+    constructor() {
+        this.userService = new UserService();
+    }
+
+    private parseFilters(req: Request): UserFilters {
+        const { search, role } = req.query;
+        return {
+            search: typeof search === 'string' && search.length > 0 ? search : undefined,
+            role: typeof role === 'string' && role.length > 0 ? role : undefined,
+        };
+    }
+
+    register = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
+    {
+        try
+        {
+            const { username, email, password } = req.body;
+
+            const newUser = await this.userService.createUser(
+                username,
+                email,
+                password,
+                "user"
+            );
+
+            const { password: _p, ...userWithoutPassword } = newUser;
+
+            res.status(201).json(userWithoutPassword);
+        }
+        catch (error)
+        {
+            next(error);
+        }
+    };
+
+    login = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const { username, password } = req.body;
+            const { user, token } = await this.userService.authenticateUser(username, password);
+
+            const { password: _, ...userWithoutPassword } = user;
+
+            setAuthCookies(res, token);
+
+            res.json({ user: userWithoutPassword });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    logout = async (_req: Request, res: Response): Promise<void> => {
+        clearAuthCookies(res);
+        res.status(204).send();
+    };
+
+    changePassword = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const authUser = req.user;
+
+            if (!authUser?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+
+            const { currentPassword, newPassword } = req.body;
+            const { user, token } = await this.userService.changePassword(
+                authUser.id,
+                currentPassword,
+                newPassword
+            );
+
+            setAuthCookies(res, token);
+
+            const { password: _, ...userWithoutPassword } = user;
+            res.json({ user: userWithoutPassword });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    getPublicUsers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const pagination = parsePagination(req.query, USERS_DEFAULT_LIMIT);
+            const filters = this.parseFilters(req);
+            const [data, total] = await this.userService.getPublicUsers(pagination, filters);
+            res.json(toPaginatedResult(data, total, pagination));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    getUserById = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const targetId = parseInt(req.params.id);
+            const authUser = req.user;
+
+            if (!authUser?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+
+            const isSelf = authUser.id === targetId;
+            const isPrivileged = authUser.role === "admin" || authUser.role === "superadmin";
+
+            if (!isSelf && !isPrivileged) {
+                res.status(403).json({ error: "Forbidden" });
+                return;
+            }
+
+            res.json(await this.userService.getUserById(targetId));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    getProfile = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
+    {
+            try
+            {
+                const authUser = req.user
+
+                if (!authUser?.id)
+                {
+                    res.status(401).json({ error: "Unauthorized" });
+                    return;
+                }
+
+                const user = await this.userService.getProfile(authUser.id);
+                res.json(user);
+            }
+            catch (error)
+            {
+                next(error);
+            }
+    };
+
+    setRole = async (req: Request, res: Response, next: NextFunction): Promise<void> =>
+    {
+        try
+        {
+            const requester = (req as any).user as { id: number; role: string };
+
+            const targetId    = parseInt(req.params.id);
+            const desiredRole = req.body.role;
+
+            const updated = await this.userService.changeUserRole(
+                requester,
+                targetId,
+                desiredRole,
+                { ip: req.ip ?? req.socket.remoteAddress }
+            );
+
+            res.json(this.userService.toPublicUser(updated));
+        }
+        catch (error)
+        {
+            next(error);
+        }
+    };
+}
+

--- a/BE/src/modules/user/user.schema.ts
+++ b/BE/src/modules/user/user.schema.ts
@@ -24,7 +24,7 @@ export const changePasswordSchema = z.object({
 });
 
 export const changeUserRoleSchema = z.object({
-    role: z.enum(['user', 'admin', 'superadmin'], {
-        message: "Role must be user, admin, or superadmin",
+    role: z.enum(['user', 'captain', 'vice_captain', 'court_captain', 'admin', 'superadmin'], {
+        message: "Role must be user, captain, vice_captain, court_captain, admin, or superadmin",
     }),
 });

--- a/BE/src/modules/user/user.service.ts
+++ b/BE/src/modules/user/user.service.ts
@@ -3,14 +3,19 @@ import { User } from "./user.entity.js";
 import { RoleAuditLog } from "./role-audit-log.entity.js";
 import { AppDataSource } from "../../db/data-source.js";
 import bcrypt from "bcryptjs";
-import jwt from "jsonwebtoken";
 import { MissingFieldError } from "../../errors/MissingFieldError.js";
 import { NotFoundError } from "../../errors/NotFoundError.js";
 import { ConflictError } from "../../errors/ConflictError.js";
 import { UnauthorizedError } from "../../errors/UnauthorizedError.js";
 import { PaginationParams } from "../../utils/pagination.js";
-import { getJwtSecret } from "../../middleware/authValidation.js";
+import {
+    signUserToken,
+    normalizeRobloxUsername,
+    ALLOWED_JWT_ROLES,
+    type AllowedJwtRole,
+} from "../../middleware/authValidation.js";
 import { validatePasswordStrength } from "../../utils/passwordPolicy.js";
+import { Players } from "../players/player.entity.js";
 
 export interface UserFilters {
     search?: string;
@@ -21,13 +26,17 @@ export interface RoleChangeAuditContext {
     ip?: string;
 }
 
+const ALL_ROLES = [...ALLOWED_JWT_ROLES];
+
 export class UserService {
     private userRepository: Repository<User>;
     private auditLogRepository: Repository<RoleAuditLog>;
+    private playerRepository: Repository<Players>;
 
     constructor() {
         this.userRepository = AppDataSource.getRepository(User);
         this.auditLogRepository = AppDataSource.getRepository(RoleAuditLog);
+        this.playerRepository = AppDataSource.getRepository(Players);
     }
 
     private async hashPassword(password: string): Promise<string> {
@@ -38,28 +47,38 @@ export class UserService {
         return await bcrypt.compare(password, hashedPassword);
     }
 
-    async createUser(username: string, email: string, password: string, role: string = 'user'): Promise<User> {
+    toPublicUser(user: User): Record<string, unknown> {
+        return {
+            id: user.id,
+            username: user.username,
+            email: user.email,
+            role: user.role,
+            robloxUserId: user.robloxUserId ?? null,
+            robloxUsername: user.robloxUsername ?? null,
+            hasPassword: Boolean(user.password),
+            createdAt: user.createdAt,
+            updatedAt: user.updatedAt,
+            articles: (user as User & { articles?: unknown }).articles,
+        };
+    }
+
+    async createUser(username: string, email: string, password: string, role: string = "user"): Promise<User> {
         if (!username) throw new MissingFieldError("Username");
         if (!email) throw new MissingFieldError("Email");
         validatePasswordStrength(password);
 
         const existingUser = await this.userRepository.findOne({
-            where: [
-                { username },
-                { email }
-            ]
+            where: [{ username }, { email }],
         });
 
         if (existingUser) {
             throw new ConflictError("User already exists");
         }
 
-        const hashedPassword = await this.hashPassword(password);
-
         const user = new User();
         user.username = username;
         user.email = email;
-        user.password = hashedPassword;
+        user.password = await this.hashPassword(password);
         user.role = role;
 
         return await this.userRepository.save(user);
@@ -68,32 +87,32 @@ export class UserService {
     private buildWhere(filters: UserFilters): FindOptionsWhere<User> {
         const where: FindOptionsWhere<User> = {};
         if (filters.search) where.username = ILike(`%${filters.search}%`);
-        if (filters.role) where.role = filters.role as User['role'];
+        if (filters.role) where.role = filters.role as User["role"];
         return where;
     }
 
     async getAllUsers(pagination: PaginationParams, filters: UserFilters = {}): Promise<[User[], number]> {
         return await this.userRepository.findAndCount({
             where: this.buildWhere(filters),
-            select: ['id', 'username', 'email', 'role', 'createdAt'],
+            select: ["id", "username", "email", "role", "robloxUsername", "robloxUserId", "createdAt"],
             skip: pagination.skip,
-            take: pagination.take
+            take: pagination.take,
         });
     }
 
     async getPublicUsers(pagination: PaginationParams, filters: UserFilters = {}): Promise<[User[], number]> {
         return await this.userRepository.findAndCount({
             where: this.buildWhere(filters),
-            select: ['id', 'username', 'role', 'createdAt'],
+            select: ["id", "username", "role", "robloxUsername", "createdAt"],
             skip: pagination.skip,
-            take: pagination.take
+            take: pagination.take,
         });
     }
 
     async getUserById(id: number): Promise<User> {
         const user = await this.userRepository.findOne({
             where: { id },
-            select: ["id", "username", "role", "createdAt"]
+            select: ["id", "username", "role", "robloxUsername", "robloxUserId", "createdAt"],
         });
 
         if (!user) {
@@ -103,52 +122,49 @@ export class UserService {
         return user;
     }
 
-    async authenticateUser(username: string, password: string): Promise<{ user: User, token: string }> {
+    async authenticateUser(username: string, password: string): Promise<{ user: User; token: string }> {
         if (!username) throw new MissingFieldError("Username");
         if (!password) throw new MissingFieldError("Password");
 
         const passwordUser = await this.userRepository.findOne({
             where: { username },
-            select: ["password"],
+            select: ["id", "password"],
         });
 
-        if (!passwordUser || !(await this.verifyPassword(password, passwordUser.password))) {
+        if (!passwordUser?.password || !(await this.verifyPassword(password, passwordUser.password))) {
             throw new UnauthorizedError("Invalid username or password");
         }
 
         const user = await this.userRepository.findOne({
             where: { username },
-            select: ["id", "username", "role", "createdAt", "tokenVersion"],
+            select: ["id", "username", "email", "role", "createdAt", "tokenVersion", "robloxUserId", "robloxUsername"],
         });
 
         if (!user) {
             throw new UnauthorizedError("Invalid username or password");
         }
 
-        const token = jwt.sign(
-            {
-                id: user.id,
-                username: user.username,
-                role: user.role,
-                tokenVersion: user.tokenVersion,
-            },
-            getJwtSecret(),
-            { expiresIn: '7d' }
-        );
-
-        return { user, token };
+        return { user, token: signUserToken(user) };
     }
 
-    async changePassword(userId: number, currentPassword: string, newPassword: string): Promise<{ user: User; token: string }> {
+    async changePassword(
+        userId: number,
+        currentPassword: string,
+        newPassword: string
+    ): Promise<{ user: User; token: string }> {
         validatePasswordStrength(newPassword);
 
         const user = await this.userRepository.findOne({
             where: { id: userId },
-            select: ["id", "username", "email", "password", "role", "tokenVersion", "createdAt", "updatedAt"],
+            select: ["id", "username", "email", "password", "role", "tokenVersion", "createdAt", "updatedAt", "robloxUserId", "robloxUsername"],
         });
 
         if (!user) {
             throw new NotFoundError("User not found");
+        }
+
+        if (!user.password) {
+            throw new UnauthorizedError("This account has no password. Set one from profile after SSO signup, or use Roblox login.");
         }
 
         if (!(await this.verifyPassword(currentPassword, user.password))) {
@@ -159,47 +175,188 @@ export class UserService {
         user.tokenVersion += 1;
         const saved = await this.userRepository.save(user);
 
-        const token = jwt.sign(
-            {
-                id: saved.id,
-                username: saved.username,
-                role: saved.role,
-                tokenVersion: saved.tokenVersion,
-            },
-            getJwtSecret(),
-            { expiresIn: '7d' }
-        );
-
-        const { password: _password, ...userWithoutPassword } = saved;
-        return { user: userWithoutPassword as User, token };
+        return { user: saved, token: signUserToken(saved) };
     }
 
-    async getProfile(userId: number): Promise<User> {
+    async getProfile(userId: number): Promise<Record<string, unknown>> {
         const user = await this.userRepository.findOne({
             where: { id: userId },
-            relations: ["articles"]
+            relations: ["articles"],
+            select: [
+                "id",
+                "username",
+                "email",
+                "role",
+                "tokenVersion",
+                "robloxUserId",
+                "robloxUsername",
+                "password",
+                "createdAt",
+                "updatedAt",
+            ],
         });
 
         if (!user) {
             throw new NotFoundError("User not found");
         }
 
-        return user;
+        return this.toPublicUser(user);
+    }
+
+    async linkPlayersToUser(user: User): Promise<void> {
+        if (!user.robloxUsername && !user.robloxUserId) return;
+
+        const qb = this.playerRepository.createQueryBuilder("player");
+        if (user.robloxUserId) {
+            qb.where("player.robloxUserId = :rid", { rid: user.robloxUserId });
+        }
+        if (user.robloxUsername) {
+            const clause = "LOWER(player.robloxUsername) = :rname";
+            if (user.robloxUserId) {
+                qb.orWhere(clause, { rname: normalizeRobloxUsername(user.robloxUsername) });
+            } else {
+                qb.where(clause, { rname: normalizeRobloxUsername(user.robloxUsername) });
+            }
+        }
+
+        const players = await qb.getMany();
+        for (const player of players) {
+            player.userId = user.id;
+            if (user.robloxUserId) player.robloxUserId = user.robloxUserId;
+            if (user.robloxUsername) player.robloxUsername = normalizeRobloxUsername(user.robloxUsername);
+            await this.playerRepository.save(player);
+        }
+    }
+
+    async connectRoblox(
+        userId: number,
+        robloxUserId: string,
+        robloxUsername: string
+    ): Promise<User> {
+        const normalized = normalizeRobloxUsername(robloxUsername);
+
+        const taken = await this.userRepository.findOne({
+            where: [{ robloxUserId }, { robloxUsername: normalized }],
+        });
+        if (taken && taken.id !== userId) {
+            throw new ConflictError("This Roblox account is already linked to another user");
+        }
+
+        const user = await this.userRepository.findOne({ where: { id: userId } });
+        if (!user) throw new NotFoundError("User not found");
+
+        user.robloxUserId = robloxUserId;
+        user.robloxUsername = normalized;
+        const saved = await this.userRepository.save(user);
+        await this.linkPlayersToUser(saved);
+        return saved;
+    }
+
+    async unlinkRoblox(userId: number): Promise<User> {
+        const user = await this.userRepository.findOne({
+            where: { id: userId },
+            select: ["id", "username", "email", "password", "role", "tokenVersion", "robloxUserId", "robloxUsername", "createdAt", "updatedAt"],
+        });
+        if (!user) throw new NotFoundError("User not found");
+
+        if (!user.password) {
+            throw new ConflictError("Cannot unlink Roblox from an account with no password. Set a password first.");
+        }
+
+        await this.playerRepository
+            .createQueryBuilder()
+            .update(Players)
+            .set({ userId: null })
+            .where("userId = :userId", { userId })
+            .execute();
+
+        user.robloxUserId = null;
+        user.robloxUsername = null;
+        return await this.userRepository.save(user);
+    }
+
+    async findByRobloxUserId(robloxUserId: string): Promise<User | null> {
+        return await this.userRepository.findOne({
+            where: { robloxUserId },
+            select: ["id", "username", "email", "role", "tokenVersion", "robloxUserId", "robloxUsername", "createdAt"],
+        });
+    }
+
+    async createUserFromRoblox(robloxUserId: string, robloxUsername: string): Promise<{ user: User; token: string }> {
+        const normalized = normalizeRobloxUsername(robloxUsername);
+        const existing = await this.findByRobloxUserId(robloxUserId);
+        if (existing) {
+            return { user: existing, token: signUserToken(existing) };
+        }
+
+        let username = normalized.slice(0, 24) || `roblox_${robloxUserId}`;
+        const takenName = await this.userRepository.findOne({ where: { username } });
+        if (takenName) {
+            username = `${username}_${robloxUserId.slice(-4)}`;
+        }
+
+        const user = new User();
+        user.username = username;
+        user.email = null;
+        user.password = null;
+        user.role = "user";
+        user.robloxUserId = robloxUserId;
+        user.robloxUsername = normalized;
+
+        const saved = await this.userRepository.save(user);
+        await this.linkPlayersToUser(saved);
+        return { user: saved, token: signUserToken(saved) };
+    }
+
+    async issueTokenForUser(userId: number): Promise<{ user: User; token: string }> {
+        const user = await this.userRepository.findOne({
+            where: { id: userId },
+            select: ["id", "username", "email", "role", "tokenVersion", "robloxUserId", "robloxUsername", "createdAt"],
+        });
+        if (!user) throw new NotFoundError("User not found");
+        return { user, token: signUserToken(user) };
+    }
+
+    async promoteRoleIfUser(
+        userId: number,
+        desired: "captain" | "vice_captain" | "court_captain",
+        actorId: number,
+        audit?: RoleChangeAuditContext
+    ): Promise<User | null> {
+        const user = await this.userRepository.findOne({ where: { id: userId } });
+        if (!user) return null;
+        if (user.role === "admin" || user.role === "superadmin") return user;
+        if (user.role === "captain" && desired !== "captain") return user;
+        if (user.role === desired) return user;
+
+        const oldRole = user.role;
+        user.role = desired;
+        user.tokenVersion += 1;
+        const saved = await this.userRepository.save(user);
+
+        const auditEntry = new RoleAuditLog();
+        auditEntry.actorId = actorId;
+        auditEntry.targetId = userId;
+        auditEntry.oldRole = oldRole;
+        auditEntry.newRole = desired;
+        auditEntry.ip = audit?.ip ?? null;
+        await this.auditLogRepository.save(auditEntry);
+
+        return saved;
     }
 
     async changeUserRole(
-        requester: { id: number; role: "user" | "admin" | "superadmin" },
-        targetId:  number,
-        desired:   "user" | "admin" | "superadmin",
-        audit?:    RoleChangeAuditContext
-    ): Promise<User>
-    {
+        requester: { id: number; role: string },
+        targetId: number,
+        desired: AllowedJwtRole,
+        audit?: RoleChangeAuditContext
+    ): Promise<User> {
         if (requester.role !== "superadmin") {
             throw new UnauthorizedError("Only superadmin can change user roles");
         }
 
-        if (!["user", "admin", "superadmin"].includes(desired)) {
-            throw new Error("Invalid role. Role must be user, admin, or superadmin");
+        if (!ALL_ROLES.includes(desired)) {
+            throw new Error(`Invalid role. Role must be one of: ${ALL_ROLES.join(", ")}`);
         }
 
         const target = await this.userRepository.findOne({ where: { id: targetId } });

--- a/FE/src/components/portal/UsersPage.tsx
+++ b/FE/src/components/portal/UsersPage.tsx
@@ -12,7 +12,7 @@ import "../../styles/UsersPage.css";
 import "../../styles/PortalPlayersPage.css";
 
 const USERS_PER_PAGE = 10;
-const ALL_ROLES: User["role"][] = ["user", "admin", "superadmin"];
+const ALL_ROLES: User["role"][] = ["user", "captain", "vice_captain", "court_captain", "admin", "superadmin"];
 
 const UsersPage: React.FC = () => {
   const { user: me } = useAuth();

--- a/FE/src/types/interfaces.ts
+++ b/FE/src/types/interfaces.ts
@@ -52,14 +52,104 @@ interface Award
   updatedAt: Date;
 }
 
+type Role = "user" | "captain" | "vice_captain" | "court_captain" | "admin" | "superadmin"
+
+interface User 
+{
+  id: number;
+  username: string;
+  email: string | null;
+  articles?: Article[]; 
+  role: Role;
+  robloxUserId?: string | null;
+  robloxUsername?: string | null;
+  hasPassword?: boolean;
+}
+
 interface Player 
 {
   id: number;
   name: string;
   position: string;
+  robloxUsername?: string | null;
+  robloxUserId?: string | null;
+  discordUsername?: string | null;
+  userId?: number | null;
   teams?: Team[]; 
   stats?: Stats[];
   awards?: Award[];
+}
+
+interface Team 
+{
+  id: number;
+  placement: string;
+  name: string;
+  logoUrl?: string;
+  hexColor?: string | null;
+  brickColor?: string | null;
+  captainEditEnabled?: boolean;
+  captainUserId?: number | null;
+  viceCaptainUserId?: number | null;
+  courtCaptainUserId?: number | null;
+  captainCanEdit?: boolean;
+  staffRole?: "captain" | "vice_captain" | "court_captain" | null;
+  season: Season;
+  regionId?: number;
+  region?: Region;
+  games?: Game[]; 
+  players?: Player[]; 
+}
+
+interface Season 
+{
+  id: number;
+  seasonNumber: number;
+  games?: Game[]; 
+  teams?: Team[]; 
+  startDate: Date; 
+  endDate?: Date; 
+  image?: string;
+  theme: string;
+  regionId?: number;
+  region?: Region;
+  registrationsOpen?: boolean;
+  captainEditEnabled?: boolean;
+  maxTeams?: number | null;
+}
+
+export type TeamRegistrationStatus = "pending" | "conflict" | "accepted" | "denied";
+
+export interface TeamRegistrationRosterEntry {
+  discord: string;
+  roblox: string;
+}
+
+export interface TeamRegistration {
+  id: number;
+  teamName: string;
+  captainDiscord: string;
+  captainRoblox: string;
+  viceDiscord?: string;
+  viceRoblox?: string;
+  hexColor?: string;
+  brickColor?: string;
+  roster?: TeamRegistrationRosterEntry[];
+  status: TeamRegistrationStatus;
+  regionId: number;
+  seasonId: number;
+  region?: Region;
+  season?: Partial<Season>;
+  agreeCivilScheduling?: boolean;
+  confidentWillParticipate?: boolean;
+  priorLeagueExperience?: string | null;
+  logoJerseyAck?: boolean;
+  createdTeamId?: number | null;
+  captainLinkPending?: boolean;
+  conflictPayload?: { conflicts?: Array<Record<string, unknown>> } | null;
+  submittedByUserId?: number;
+  submittedBy?: { id: number; username: string };
+  createdAt?: string;
 }
 interface Stats
 {
@@ -108,33 +198,6 @@ interface Stats
     plusMinus?: number;
 }
 
-interface Team 
-{
-  id: number;
-  placement: string;
-  name: string;
-  logoUrl?: string;
-  season: Season;
-  regionId?: number;
-  region?: Region;
-  games?: Game[]; 
-  players?: Player[]; 
-}
-
-interface Season 
-{
-  id: number;
-  seasonNumber: number;
-  games?: Game[]; 
-  teams?: Team[]; 
-  startDate: Date; 
-  endDate?: Date; 
-  image?: string;
-  theme: string;
-  regionId?: number;
-  region?: Region;
-}
-
 interface Article 
 {
   id: number;
@@ -146,17 +209,6 @@ interface Article
   imageUrl: string; 
   likes: number;
   approved: boolean | null;
-}
-
-type Role = "user" | "admin" | "superadmin"
-
-interface User 
-{
-  id: number;
-  username: string;
-  email: string;
-  articles?: Article[]; 
-  role: Role; 
 }
 
 interface Records


### PR DESCRIPTION
## Summary
- Expand JWT/role allowlists to `captain`, `vice_captain`, and `court_captain`
- Update user role change APIs and FE Users portal promote/filter options
- Extend shared FE domain types for the portal

## Test plan
- [ ] Superadmin can assign the new roles on `/portal/users`
- [ ] Existing login/JWT still works for `user` / `admin` / `superadmin`
- [ ] Invalid legacy role tokens are rejected as before

**Base:** `feat/team-app-schema` (merge schema PR first)