### PR TITLE
Add Roblox SSO connect, signup, and login

### DIFF
--- a/BE/src/modules/roblox/roblox-auth.controller.ts
+++ b/BE/src/modules/roblox/roblox-auth.controller.ts
@@ -1,0 +1,236 @@
+import crypto from "crypto";
+import { Request, Response, NextFunction } from "express";
+import { UserService } from "../user/user.service.js";
+import { setAuthCookies } from "../../middleware/authCookie.js";
+import { ConflictError } from "../../errors/ConflictError.js";
+import { UnauthorizedError } from "../../errors/UnauthorizedError.js";
+import { getJwtSecret } from "../../middleware/authValidation.js";
+
+export type RobloxOAuthIntent = "connect" | "signup" | "login";
+
+const AUTHORIZE_URL = "https://apis.roblox.com/oauth/v1/authorize";
+const TOKEN_URL = "https://apis.roblox.com/oauth/v1/token";
+const USERINFO_URL = "https://apis.roblox.com/oauth/v1/userinfo";
+const STATE_COOKIE = "roblox_oauth_state";
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+interface OAuthStatePayload {
+    intent: RobloxOAuthIntent;
+    userId?: number;
+    nonce: string;
+    exp: number;
+}
+
+function getFrontendUrl(): string {
+    return process.env.FRONTEND_URL || process.env.CORS_ORIGINS?.split(",")[0]?.trim() || "http://localhost:5173";
+}
+
+function getRobloxConfig(): { clientId: string; clientSecret: string; redirectUri: string } {
+    const clientId = process.env.ROBLOX_OAUTH_CLIENT_ID;
+    const clientSecret = process.env.ROBLOX_OAUTH_CLIENT_SECRET;
+    const redirectUri =
+        process.env.ROBLOX_OAUTH_REDIRECT_URI ||
+        `${process.env.BACKEND_PUBLIC_URL || "http://localhost:3000"}/api/auth/roblox/callback`;
+
+    if (!clientId || !clientSecret) {
+        throw new Error("Roblox OAuth is not configured (ROBLOX_OAUTH_CLIENT_ID / ROBLOX_OAUTH_CLIENT_SECRET)");
+    }
+
+    return { clientId, clientSecret, redirectUri };
+}
+
+function signState(payload: OAuthStatePayload): string {
+    const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const sig = crypto.createHmac("sha256", getJwtSecret()).update(body).digest("base64url");
+    return `${body}.${sig}`;
+}
+
+function verifyState(state: string): OAuthStatePayload {
+    const [body, sig] = state.split(".");
+    if (!body || !sig) throw new UnauthorizedError("Invalid OAuth state");
+    const expected = crypto.createHmac("sha256", getJwtSecret()).update(body).digest("base64url");
+    if (sig.length !== expected.length || !crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+        throw new UnauthorizedError("Invalid OAuth state signature");
+    }
+    const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8")) as OAuthStatePayload;
+    if (payload.exp < Date.now()) throw new UnauthorizedError("OAuth state expired");
+    return payload;
+}
+
+export class RobloxAuthController {
+    private userService = new UserService();
+
+    start = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const intent = (req.query.intent as RobloxOAuthIntent) || "login";
+            if (!["connect", "signup", "login"].includes(intent)) {
+                res.status(400).json({ error: "intent must be connect, signup, or login" });
+                return;
+            }
+
+            if (intent === "connect" && !req.user?.id) {
+                res.status(401).json({ error: "Must be logged in to connect Roblox" });
+                return;
+            }
+
+            const { clientId, redirectUri } = getRobloxConfig();
+            const payload: OAuthStatePayload = {
+                intent,
+                userId: intent === "connect" ? req.user!.id : undefined,
+                nonce: crypto.randomBytes(16).toString("hex"),
+                exp: Date.now() + STATE_TTL_MS,
+            };
+            const state = signState(payload);
+
+            res.cookie(STATE_COOKIE, state, {
+                httpOnly: true,
+                sameSite: "lax",
+                secure: process.env.NODE_ENV === "production",
+                maxAge: STATE_TTL_MS,
+                path: "/",
+            });
+
+            const url = new URL(AUTHORIZE_URL);
+            url.searchParams.set("client_id", clientId);
+            url.searchParams.set("redirect_uri", redirectUri);
+            url.searchParams.set("scope", "openid profile");
+            url.searchParams.set("response_type", "code");
+            url.searchParams.set("state", state);
+
+            res.json({ url: url.toString() });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    callback = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        const frontend = getFrontendUrl();
+        try {
+            const code = typeof req.query.code === "string" ? req.query.code : null;
+            const state = typeof req.query.state === "string" ? req.query.state : req.cookies?.[STATE_COOKIE];
+            const oauthError = typeof req.query.error === "string" ? req.query.error : null;
+
+            if (oauthError) {
+                res.redirect(`${frontend}/login?roblox=error&message=${encodeURIComponent(oauthError)}`);
+                return;
+            }
+            if (!code || !state) {
+                res.redirect(`${frontend}/login?roblox=error&message=${encodeURIComponent("Missing code or state")}`);
+                return;
+            }
+
+            const payload = verifyState(state);
+            const { clientId, clientSecret, redirectUri } = getRobloxConfig();
+
+            const tokenRes = await fetch(TOKEN_URL, {
+                method: "POST",
+                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                body: new URLSearchParams({
+                    grant_type: "authorization_code",
+                    code,
+                    client_id: clientId,
+                    client_secret: clientSecret,
+                    redirect_uri: redirectUri,
+                }),
+            });
+
+            if (!tokenRes.ok) {
+                const text = await tokenRes.text();
+                console.error("Roblox token exchange failed", text);
+                res.redirect(`${frontend}/login?roblox=error&message=${encodeURIComponent("Token exchange failed")}`);
+                return;
+            }
+
+            const tokenJson = (await tokenRes.json()) as { access_token: string };
+            const infoRes = await fetch(USERINFO_URL, {
+                headers: { Authorization: `Bearer ${tokenJson.access_token}` },
+            });
+            if (!infoRes.ok) {
+                res.redirect(`${frontend}/login?roblox=error&message=${encodeURIComponent("Failed to fetch Roblox profile")}`);
+                return;
+            }
+
+            const info = (await infoRes.json()) as {
+                sub?: string;
+                preferred_username?: string;
+                nickname?: string;
+                name?: string;
+            };
+
+            const robloxUserId = String(info.sub || "");
+            const robloxUsername = info.preferred_username || info.nickname || info.name || "";
+            if (!robloxUserId || !robloxUsername) {
+                res.redirect(`${frontend}/login?roblox=error&message=${encodeURIComponent("Incomplete Roblox profile")}`);
+                return;
+            }
+
+            res.clearCookie(STATE_COOKIE, { path: "/" });
+
+            if (payload.intent === "connect") {
+                if (!payload.userId) {
+                    res.redirect(`${frontend}/profile?roblox=error&message=${encodeURIComponent("Not logged in")}`);
+                    return;
+                }
+                await this.userService.connectRoblox(payload.userId, robloxUserId, robloxUsername);
+                const { user, token } = await this.userService.issueTokenForUser(payload.userId);
+                setAuthCookies(res, token);
+                res.redirect(`${frontend}/profile?roblox=connected&user=${encodeURIComponent(user.robloxUsername || robloxUsername)}`);
+                return;
+            }
+
+            if (payload.intent === "login") {
+                const existing = await this.userService.findByRobloxUserId(robloxUserId);
+                if (!existing) {
+                    res.redirect(`${frontend}/signup?roblox=need_signup`);
+                    return;
+                }
+                const { token } = await this.userService.issueTokenForUser(existing.id);
+                setAuthCookies(res, token);
+                res.redirect(`${frontend}/?roblox=login`);
+                return;
+            }
+
+            // signup
+            const existing = await this.userService.findByRobloxUserId(robloxUserId);
+            if (existing) {
+                const { token } = await this.userService.issueTokenForUser(existing.id);
+                setAuthCookies(res, token);
+                res.redirect(`${frontend}/?roblox=login`);
+                return;
+            }
+
+            const { token } = await this.userService.createUserFromRoblox(robloxUserId, robloxUsername);
+            setAuthCookies(res, token);
+            res.redirect(`${frontend}/?roblox=signup`);
+        } catch (error) {
+            if (error instanceof ConflictError) {
+                res.redirect(`${frontend}/profile?roblox=error&message=${encodeURIComponent(error.message)}`);
+                return;
+            }
+            next(error);
+        }
+    };
+
+    unlink = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const user = await this.userService.unlinkRoblox(req.user.id);
+            res.json(this.userService.toPublicUser(user));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    adminUnlink = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const targetId = Number(req.params.id);
+            const user = await this.userService.unlinkRoblox(targetId);
+            res.json(this.userService.toPublicUser(user));
+        } catch (error) {
+            next(error);
+        }
+    };
+}

--- a/BE/src/modules/roblox/roblox.routes.ts
+++ b/BE/src/modules/roblox/roblox.routes.ts
@@ -1,13 +1,39 @@
 import { Application, Router } from 'express';
 import { RobloxController } from './roblox.controller.js';
+import { RobloxAuthController } from './roblox-auth.controller.js';
 import { robloxRateLimiter } from '../../middleware/rateLimit.js';
+import { authenticateToken } from '../../middleware/authentication.js';
+import { authorizeRoles } from '../../middleware/authorizeRoles.js';
 
 export function registerRobloxRoutes(app: Application): void
 {
     const router = Router();
     const robloxController = new RobloxController();
+    const authController = new RobloxAuthController();
 
     router.get('/avatar/:username', robloxRateLimiter, robloxController.getAvatarByUsername);
 
     app.use('/api/roblox', router);
+
+    const authRouter = Router();
+    authRouter.get('/roblox/start', (req, res, next) => {
+        // connect requires auth; login/signup do not
+        if (req.query.intent === 'connect') {
+            return authenticateToken(req, res, (err?: unknown) => {
+                if (err) return next(err);
+                return authController.start(req, res, next);
+            });
+        }
+        return authController.start(req, res, next);
+    });
+    authRouter.get('/roblox/callback', authController.callback);
+    authRouter.post('/roblox/unlink', authenticateToken, authController.unlink);
+    authRouter.post(
+        '/roblox/unlink/:id',
+        authenticateToken,
+        authorizeRoles('admin', 'superadmin'),
+        authController.adminUnlink
+    );
+
+    app.use('/api/auth', authRouter);
 }

--- a/BE/src/modules/stats/stat.schema.ts
+++ b/BE/src/modules/stats/stat.schema.ts
@@ -31,6 +31,6 @@ export const createStatByNameSchema = createStatSchema
   });
 
 export type CreateStatDto = z.infer<typeof createStatSchema>;
-export type UpdateStatDto = z.infer<typeof createStatSchema.partial()>;
+export type UpdateStatDto = z.infer<typeof updateStatSchema>;
 export type CreateStatByNameDto = z.infer<typeof createStatByNameSchema>;
 

--- a/FE/src/components/Login.tsx
+++ b/FE/src/components/Login.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useLogin } from "../hooks/useLogin";
+import { startRobloxOAuth } from "../hooks/useTeamRegistrations";
 import "../styles/Login.css";
 
 const LoginPage: React.FC = () =>
@@ -14,6 +15,17 @@ const LoginPage: React.FC = () =>
     // form state
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
+    const [oauthError, setOauthError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get("roblox") === "error") {
+            setOauthError(params.get("message") || "Roblox login failed");
+        }
+        if (params.get("roblox") === "need_signup") {
+            setOauthError("No account linked to that Roblox user. Sign up with Roblox instead.");
+        }
+    }, []);
 
     // on form submit
     const handleSubmit = async (e: React.FormEvent) =>
@@ -31,7 +43,7 @@ const LoginPage: React.FC = () =>
     return (
         <div className="auth-container">
             <h2>Login</h2>
-            {error && <div className="auth-error">{error}</div>}
+            {(error || oauthError) && <div className="auth-error">{error || oauthError}</div>}
             <form onSubmit={handleSubmit} className="auth-form">
                 <label>
                     Username
@@ -55,6 +67,13 @@ const LoginPage: React.FC = () =>
                     {loading ? "Logging in…" : "Login"}
                 </button>
             </form>
+            <button
+                type="button"
+                className="auth-sso-btn"
+                onClick={() => void startRobloxOAuth("login").catch((e) => setOauthError(String(e.message || e)))}
+            >
+                Log in with Roblox
+            </button>
             <p>
                 Don’t have an account?{" "}
                 <Link className="auth-link" to="/signup">

--- a/FE/src/components/SignUp.tsx
+++ b/FE/src/components/SignUp.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Link, useNavigate }        from "react-router-dom";
 import { useSignup }          from "../hooks/useSignUp";
+import { startRobloxOAuth } from "../hooks/useTeamRegistrations";
 import "../styles/Login.css";
 
 const SignupPage: React.FC = () =>
@@ -104,6 +105,14 @@ const SignupPage: React.FC = () =>
                     {loading ? "Signing up…" : "Sign Up"}
                 </button>
             </form>
+
+            <button
+                type="button"
+                className="auth-sso-btn"
+                onClick={() => void startRobloxOAuth("signup").catch((e) => alert(String(e.message || e)))}
+            >
+                Sign up with Roblox
+            </button>
 
             <p>
                 Already have an account?{' '}

--- a/FE/src/components/UserProfile.tsx
+++ b/FE/src/components/UserProfile.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 import { authFetch } from "../hooks/authFetch";
 import { useAuth } from "../context/authContext";
 import { BACKEND_URL } from "../constants/api";
+import { startRobloxOAuth } from "../hooks/useTeamRegistrations";
 import "../styles/UserProfile.css";
 
 interface Article {
@@ -17,10 +18,13 @@ interface Article {
 interface UserProfile {
     id:        number;
     username:  string;
-    email:     string;
+    email:     string | null;
     role:      string;
     createdAt: string;
     updatedAt: string;
+    robloxUsername?: string | null;
+    robloxUserId?: string | null;
+    hasPassword?: boolean;
     articles?: Article[];
 }
 
@@ -113,11 +117,42 @@ const ProfilePage: React.FC = () =>
 
             <div className="profile-card">
                 <p><strong>Username:</strong> {profile.username}</p>
-                <p><strong>Email:</strong>    {profile.email}</p>
+                <p><strong>Email:</strong>    {profile.email || "—"}</p>
                 <p>
                     <strong>Role / Permissions level:</strong>{" "}
                     {profile.role}
                 </p>
+                <p>
+                    <strong>Roblox:</strong>{" "}
+                    {profile.robloxUsername ? `@${profile.robloxUsername}` : "Not connected"}
+                </p>
+                <div className="profile-roblox-actions">
+                    {!profile.robloxUsername ? (
+                        <button type="button" onClick={() => void startRobloxOAuth("connect")}>
+                            Connect Roblox
+                        </button>
+                    ) : (
+                        <button
+                            type="button"
+                            onClick={async () => {
+                                const res = await authFetch(
+                                    `${BACKEND_URL}/api/auth/roblox/unlink`,
+                                    { method: "POST" },
+                                    token
+                                );
+                                if (res.ok) {
+                                    const data = await res.json();
+                                    setProfile((p) => (p ? { ...p, ...data } : p));
+                                } else {
+                                    const data = await res.json().catch(() => ({}));
+                                    alert(data.error || "Failed to unlink");
+                                }
+                            }}
+                        >
+                            Disconnect Roblox
+                        </button>
+                    )}
+                </div>
                 <p>
                     <strong>Join Date:</strong>{" "}
                     {new Date(profile.createdAt).toLocaleDateString()}

--- a/FE/src/hooks/useTeamRegistrations.ts
+++ b/FE/src/hooks/useTeamRegistrations.ts
@@ -1,0 +1,67 @@
+import { authFetch } from "./authFetch";
+import { BACKEND_URL } from "../constants/api";
+import type { TeamRegistration, RegionCode } from "../types/interfaces";
+import { useEffect, useState, useCallback } from "react";
+
+export function useTeamRegistrations(params: {
+  region?: RegionCode;
+  seasonId?: number;
+  full?: boolean;
+}) {
+  const [data, setData] = useState<TeamRegistration[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const q = new URLSearchParams();
+      if (params.region) q.set("region", params.region);
+      if (params.seasonId) q.set("seasonId", String(params.seasonId));
+      if (params.full) q.set("full", "1");
+      const res = await authFetch(`${BACKEND_URL}/api/team-registrations?${q.toString()}`);
+      if (!res.ok) throw new Error("Failed to load registrations");
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [params.region, params.seasonId, params.full]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return { data, loading, error, reload };
+}
+
+export function useRegistrationSummary(region?: RegionCode) {
+  const [summary, setSummary] = useState<{
+    accepted: number;
+    spotsLeft: number | null;
+    capacity: number | null;
+    seasonId: number | null;
+    startDate?: string;
+    registrationsOpen?: boolean;
+    seasonNumber?: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const q = region ? `?region=${region}` : "";
+    void fetch(`${BACKEND_URL}/api/team-registrations/summary${q}`)
+      .then((r) => r.json())
+      .then(setSummary)
+      .catch(() => setSummary(null));
+  }, [region]);
+
+  return summary;
+}
+
+export async function startRobloxOAuth(intent: "connect" | "signup" | "login") {
+  const res = await authFetch(`${BACKEND_URL}/api/auth/roblox/start?intent=${intent}`);
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || "Failed to start Roblox OAuth");
+  window.location.href = data.url;
+}

--- a/FE/src/styles/Login.css
+++ b/FE/src/styles/Login.css
@@ -138,3 +138,24 @@ body {
     margin-bottom: 1rem;         /* same spacing */
     font-size: 0.9rem;           /* same font size */
 }
+
+.auth-sso-btn {
+  display: block;
+  width: 100%;
+  margin-top: 0.75rem;
+  padding: 0.65rem 1rem;
+  background: #fff;
+  border: 1px solid #2d3c50;
+  color: #2d3c50;
+  cursor: pointer;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.auth-sso-btn:hover {
+  background: #f3f6f9;
+}
+
+.profile-roblox-actions {
+  margin: 0.5rem 0 1rem;
+}


### PR DESCRIPTION
## Summary
- Add Roblox OAuth start/callback/unlink endpoints
- Wire Login, Signup, and Profile Connect/Disconnect Roblox flows
- Share `startRobloxOAuth` helper (also hosts registration list hooks used by later UI)

## Test plan
- [ ] Set `ROBLOX_OAUTH_CLIENT_ID`, `ROBLOX_OAUTH_CLIENT_SECRET`, `ROBLOX_OAUTH_REDIRECT_URI`, `FRONTEND_URL`
- [ ] Connect Roblox from an existing logged-in profile
- [ ] Sign up with Roblox creates a session
- [ ] Log in with Roblox for a linked account; unlinked login prompts signup

**Base:** `feat/staff-roles`