### PR TITLE
Add team registration and staff-edit APIs

### DIFF
--- a/BE/src/modules/index.ts
+++ b/BE/src/modules/index.ts
@@ -12,6 +12,7 @@ import { registerRecordRoutes } from './records/records.routes.js';
 import { registerTriviaRoutes } from './trivia/trivia.routes.js';
 import { registerApplicationRoutes } from './applications/application.routes.js';
 import { registerRegionRoutes } from './regions/region.routes.js';
+import { registerTeamRegistrationRoutes } from './team-registrations/team-registration.routes.js';
 import { cacheHealthCheck } from '../middleware/cache.js';
 import { authenticateToken } from '../middleware/authentication.js';
 import { authorizeRoles } from '../middleware/authorizeRoles.js';
@@ -35,6 +36,7 @@ export function registerModules(app: Application): void
     registerRecordRoutes(app);
     registerTriviaRoutes(app);
     registerApplicationRoutes(app);
+    registerTeamRegistrationRoutes(app);
 
     // Cache health check route (admin only)
     app.get('/api/cache/health', authenticateToken, authorizeRoles("admin", "superadmin"), cacheHealthCheck);

--- a/BE/src/modules/seasons/season.controller.ts
+++ b/BE/src/modules/seasons/season.controller.ts
@@ -119,7 +119,10 @@ export class SeasonController
                 startDate,
                 endDate,
                 theme,
-                image
+                image,
+                registrationsOpen,
+                captainEditEnabled,
+                maxTeams,
             } = req.body;
 
             const updated = await this.seasonService.updateSeason(
@@ -128,7 +131,10 @@ export class SeasonController
                 startDate ? new Date(startDate) : undefined,
                 endDate   ? new Date(endDate)   : undefined,
                 theme,
-                image
+                image,
+                registrationsOpen,
+                captainEditEnabled,
+                maxTeams
             );
 
             res.status(200).json(updated);

--- a/BE/src/modules/seasons/season.schema.ts
+++ b/BE/src/modules/seasons/season.schema.ts
@@ -14,4 +14,8 @@ export const createSeasonSchema = z.object({
     region: z.enum(REGION_CODES).optional(),
 });
 
-export const updateSeasonSchema = createSeasonSchema.partial();
+export const updateSeasonSchema = createSeasonSchema.partial().extend({
+    registrationsOpen: z.boolean().optional(),
+    captainEditEnabled: z.boolean().optional(),
+    maxTeams: z.number().int().positive().nullable().optional(),
+});

--- a/BE/src/modules/seasons/season.service.ts
+++ b/BE/src/modules/seasons/season.service.ts
@@ -184,7 +184,10 @@ export class SeasonService
         startDate?: Date,
         endDate?: Date,
         theme?: string,
-        image?: string
+        image?: string,
+        registrationsOpen?: boolean,
+        captainEditEnabled?: boolean,
+        maxTeams?: number | null
     ): Promise<Seasons>
     {
         if (!id) throw new MissingFieldError("Season ID");
@@ -227,6 +230,18 @@ export class SeasonService
         if (image !== undefined)
         {
             season.image = image;
+        }
+
+        if (registrationsOpen !== undefined) {
+            season.registrationsOpen = registrationsOpen;
+        }
+
+        if (captainEditEnabled !== undefined) {
+            season.captainEditEnabled = captainEditEnabled;
+        }
+
+        if (maxTeams !== undefined) {
+            season.maxTeams = maxTeams;
         }
 
         if (season.startDate && season.endDate && season.startDate > season.endDate)

--- a/BE/src/modules/stats/stat.schema.ts
+++ b/BE/src/modules/stats/stat.schema.ts
@@ -31,6 +31,6 @@ export const createStatByNameSchema = createStatSchema
   });
 
 export type CreateStatDto = z.infer<typeof createStatSchema>;
-export type UpdateStatDto = z.infer<typeof createStatSchema.partial()>;
+export type UpdateStatDto = z.infer<typeof updateStatSchema>;
 export type CreateStatByNameDto = z.infer<typeof createStatByNameSchema>;
 

--- a/BE/src/modules/team-registrations/team-registration.controller.ts
+++ b/BE/src/modules/team-registrations/team-registration.controller.ts
@@ -1,0 +1,161 @@
+import { Request, Response, NextFunction } from "express";
+import { TeamRegistrationService } from "./team-registration.service.js";
+import { RegionCode } from "../regions/region.entity.js";
+
+export class TeamRegistrationController {
+    private service = new TeamRegistrationService();
+
+    submit = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const row = await this.service.submit(req.user.id, req.body);
+            res.status(201).json(this.service.toDetailDto(row, true));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    update = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const id = Number(req.params.id);
+            const row = await this.service.updatePending(req.user.id, id, req.body);
+            res.json(this.service.toDetailDto(row, true));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    withdraw = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            await this.service.withdraw(req.user.id, Number(req.params.id));
+            res.status(204).send();
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    list = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const region = typeof req.query.region === "string" ? (req.query.region as RegionCode) : undefined;
+            const seasonId = req.query.seasonId ? Number(req.query.seasonId) : undefined;
+            const status = typeof req.query.status === "string" ? req.query.status : undefined;
+            const rows = await this.service.list({ region, seasonId, status });
+
+            const isAdmin = req.user?.role === "admin" || req.user?.role === "superadmin";
+            if (isAdmin && req.query.full === "1") {
+                res.json(rows.map((r) => this.service.toDetailDto(r, true)));
+                return;
+            }
+            res.json(rows.map((r) => this.service.toPublicDto(r)));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    summary = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const region = typeof req.query.region === "string" ? (req.query.region as RegionCode) : undefined;
+            const seasonId = req.query.seasonId ? Number(req.query.seasonId) : undefined;
+            res.json(await this.service.summary(region, seasonId));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    getOne = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const id = Number(req.params.id);
+            const row = await this.service.getById(id);
+            const isAdmin = req.user?.role === "admin" || req.user?.role === "superadmin";
+            const isOwner = req.user?.id === row.submittedByUserId;
+            if (!isAdmin && !isOwner) {
+                res.json(this.service.toDetailDto(row, false));
+                return;
+            }
+            res.json(this.service.toDetailDto(row, isAdmin));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    accept = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const result = await this.service.tryAccept(Number(req.params.id), req.user.id);
+            if (!result.ok) {
+                res.status(409).json({
+                    error: "Conflicts detected",
+                    conflicts: result.conflicts,
+                    registration: this.service.toDetailDto(result.registration, true),
+                });
+                return;
+            }
+            res.json({
+                registration: this.service.toDetailDto(result.registration, true),
+                team: result.team,
+            });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    resolve = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const result = await this.service.resolve(Number(req.params.id), req.user.id, req.body);
+            if ("ok" in result && result.ok === false) {
+                res.status(409).json({
+                    error: "Conflicts detected",
+                    conflicts: result.conflicts,
+                    registration: this.service.toDetailDto(result.registration, true),
+                });
+                return;
+            }
+            if ("ok" in result && result.ok === true) {
+                res.json({
+                    registration: this.service.toDetailDto(result.registration, true),
+                    team: result.team,
+                });
+                return;
+            }
+            res.json({ registration: this.service.toDetailDto((result as { registration: never }).registration, true) });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    deny = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const row = await this.service.deny(Number(req.params.id));
+            res.json(this.service.toDetailDto(row, true));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    revoke = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const row = await this.service.revoke(Number(req.params.id));
+            res.json(this.service.toDetailDto(row, true));
+        } catch (error) {
+            next(error);
+        }
+    };
+}

--- a/BE/src/modules/team-registrations/team-registration.routes.ts
+++ b/BE/src/modules/team-registrations/team-registration.routes.ts
@@ -1,0 +1,69 @@
+import { Application, Router } from "express";
+import { validate } from "../../middleware/validate.js";
+import { authenticateToken } from "../../middleware/authentication.js";
+import { authorizeRoles } from "../../middleware/authorizeRoles.js";
+import { TeamRegistrationController } from "./team-registration.controller.js";
+import {
+    createTeamRegistrationSchema,
+    updateTeamRegistrationSchema,
+    resolveRegistrationSchema,
+} from "./team-registration.schema.js";
+
+/** Optional auth — attaches user if token present, never 401s. */
+function optionalAuth(req: any, res: any, next: any): void {
+    const header = req.header?.("Authorization") || "";
+    const hasCookie = Boolean(req.cookies?.auth_token);
+    if (!header && !hasCookie) {
+        next();
+        return;
+    }
+    authenticateToken(req, res, (err?: unknown) => {
+        if (err) {
+            // ignore invalid token for public list enrichment
+            next();
+            return;
+        }
+        next();
+    });
+}
+
+export function registerTeamRegistrationRoutes(app: Application): void {
+    const router = Router();
+    const controller = new TeamRegistrationController();
+
+    router.get("/", optionalAuth, controller.list);
+    router.get("/summary", controller.summary);
+    router.get("/:id", optionalAuth, controller.getOne);
+
+    router.post("/", authenticateToken, validate(createTeamRegistrationSchema), controller.submit);
+    router.patch("/:id", authenticateToken, validate(updateTeamRegistrationSchema), controller.update);
+    router.delete("/:id", authenticateToken, controller.withdraw);
+
+    router.post(
+        "/:id/accept",
+        authenticateToken,
+        authorizeRoles("admin", "superadmin"),
+        controller.accept
+    );
+    router.post(
+        "/:id/resolve",
+        authenticateToken,
+        authorizeRoles("admin", "superadmin"),
+        validate(resolveRegistrationSchema),
+        controller.resolve
+    );
+    router.post(
+        "/:id/deny",
+        authenticateToken,
+        authorizeRoles("admin", "superadmin"),
+        controller.deny
+    );
+    router.post(
+        "/:id/revoke",
+        authenticateToken,
+        authorizeRoles("admin", "superadmin"),
+        controller.revoke
+    );
+
+    app.use("/api/team-registrations", router);
+}

--- a/BE/src/modules/team-registrations/team-registration.schema.ts
+++ b/BE/src/modules/team-registrations/team-registration.schema.ts
@@ -6,41 +6,63 @@ const rosterEntrySchema = z.object({
     roblox: z.string().min(1),
 });
 
-export const createTeamRegistrationSchema = z
-    .object({
-        region: z.enum(REGION_CODES),
-        teamName: z.string().min(1).max(64),
-        hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/, { message: "hexColor must be #RRGGBB" }),
-        brickColor: z.string().min(1).max(64),
-        captainDiscord: z.string().min(1),
-        captainRoblox: z.string().min(1),
-        viceDiscord: z.string().min(1),
-        viceRoblox: z.string().min(1),
-        roster: z.array(rosterEntrySchema).min(10),
-        agreeCivilScheduling: z.literal(true),
-        confidentWillParticipate: z.literal(true),
-        priorLeagueExperience: z.string().max(2000).optional().nullable(),
-        logoJerseyAck: z.literal(true),
-    })
+const teamRegistrationFields = z.object({
+    region: z.enum(REGION_CODES),
+    teamName: z.string().min(1).max(64),
+    hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/, { message: "hexColor must be #RRGGBB" }),
+    brickColor: z.string().min(1).max(64),
+    captainDiscord: z.string().min(1),
+    captainRoblox: z.string().min(1),
+    viceDiscord: z.string().min(1),
+    viceRoblox: z.string().min(1),
+    roster: z.array(rosterEntrySchema).min(10),
+    agreeCivilScheduling: z.literal(true),
+    confidentWillParticipate: z.literal(true),
+    priorLeagueExperience: z.string().max(2000).optional().nullable(),
+    logoJerseyAck: z.literal(true),
+});
+
+function refineTeamRegistrationRoster(
+    data: {
+        roster: Array<{ roblox: string }>;
+        captainRoblox: string;
+        viceRoblox: string;
+    },
+    ctx: z.RefinementCtx
+): void {
+    const robloxes = data.roster.map((r) => r.roblox.trim().toLowerCase());
+    const unique = new Set(robloxes);
+    if (unique.size !== robloxes.length) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Duplicate Roblox usernames in roster", path: ["roster"] });
+    }
+    const captain = data.captainRoblox.trim().toLowerCase();
+    const vice = data.viceRoblox.trim().toLowerCase();
+    if (!robloxes.includes(captain)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include captain Roblox", path: ["roster"] });
+    }
+    if (!robloxes.includes(vice)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include vice Roblox", path: ["roster"] });
+    }
+}
+
+export const createTeamRegistrationSchema = teamRegistrationFields.superRefine(refineTeamRegistrationRoster);
+
+export const updateTeamRegistrationSchema = teamRegistrationFields
+    .partial()
+    .omit({ region: true })
     .superRefine((data, ctx) => {
-        const robloxes = data.roster.map((r) => r.roblox.trim().toLowerCase());
-        const unique = new Set(robloxes);
-        if (unique.size !== robloxes.length) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Duplicate Roblox usernames in roster", path: ["roster"] });
-        }
-        const captain = data.captainRoblox.trim().toLowerCase();
-        const vice = data.viceRoblox.trim().toLowerCase();
-        if (!robloxes.includes(captain)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include captain Roblox", path: ["roster"] });
-        }
-        if (!robloxes.includes(vice)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include vice Roblox", path: ["roster"] });
-        }
+        // Only enforce roster inclusion rules when enough fields are present to check.
+        if (!data.roster || !data.captainRoblox || !data.viceRoblox) return;
+        refineTeamRegistrationRoster(
+            {
+                roster: data.roster,
+                captainRoblox: data.captainRoblox,
+                viceRoblox: data.viceRoblox,
+            },
+            ctx
+        );
     });
 
-export const updateTeamRegistrationSchema = createTeamRegistrationSchema.partial().omit({
-    region: true,
-});
 
 export const resolveRegistrationSchema = z.object({
     decision: z.enum(["pending", "denied"]).optional(),

--- a/BE/src/modules/team-registrations/team-registration.schema.ts
+++ b/BE/src/modules/team-registrations/team-registration.schema.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { REGION_CODES } from "../regions/region.entity.js";
+
+const rosterEntrySchema = z.object({
+    discord: z.string().min(1),
+    roblox: z.string().min(1),
+});
+
+export const createTeamRegistrationSchema = z
+    .object({
+        region: z.enum(REGION_CODES),
+        teamName: z.string().min(1).max(64),
+        hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/, { message: "hexColor must be #RRGGBB" }),
+        brickColor: z.string().min(1).max(64),
+        captainDiscord: z.string().min(1),
+        captainRoblox: z.string().min(1),
+        viceDiscord: z.string().min(1),
+        viceRoblox: z.string().min(1),
+        roster: z.array(rosterEntrySchema).min(10),
+        agreeCivilScheduling: z.literal(true),
+        confidentWillParticipate: z.literal(true),
+        priorLeagueExperience: z.string().max(2000).optional().nullable(),
+        logoJerseyAck: z.literal(true),
+    })
+    .superRefine((data, ctx) => {
+        const robloxes = data.roster.map((r) => r.roblox.trim().toLowerCase());
+        const unique = new Set(robloxes);
+        if (unique.size !== robloxes.length) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Duplicate Roblox usernames in roster", path: ["roster"] });
+        }
+        const captain = data.captainRoblox.trim().toLowerCase();
+        const vice = data.viceRoblox.trim().toLowerCase();
+        if (!robloxes.includes(captain)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include captain Roblox", path: ["roster"] });
+        }
+        if (!robloxes.includes(vice)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include vice Roblox", path: ["roster"] });
+        }
+    });
+
+export const updateTeamRegistrationSchema = createTeamRegistrationSchema.partial().omit({
+    region: true,
+});
+
+export const resolveRegistrationSchema = z.object({
+    decision: z.enum(["pending", "denied"]).optional(),
+    teamName: z.string().min(1).max(64).optional(),
+    players: z
+        .array(
+            z.object({
+                roblox: z.string().min(1),
+                action: z.enum(["transfer", "exclude"]),
+            })
+        )
+        .optional(),
+});
+
+export type CreateTeamRegistrationDto = z.infer<typeof createTeamRegistrationSchema>;
+export type UpdateTeamRegistrationDto = z.infer<typeof updateTeamRegistrationSchema>;
+export type ResolveRegistrationDto = z.infer<typeof resolveRegistrationSchema>;
+
+export const staffTeamUpdateSchema = z.object({
+    name: z.string().min(1).max(64).optional(),
+    hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/).optional().nullable(),
+    brickColor: z.string().min(1).max(64).optional().nullable(),
+    logoUrl: z.string().url().optional().nullable(),
+    roster: z.array(rosterEntrySchema).min(10).optional(),
+    captainUserId: z.number().int().positive().optional().nullable(),
+    viceCaptainUserId: z.number().int().positive().optional().nullable(),
+    courtCaptainUserId: z.number().int().positive().optional().nullable(),
+});
+
+export const adminTeamFlagsSchema = z.object({
+    captainEditEnabled: z.boolean().optional(),
+    hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/).optional().nullable(),
+    brickColor: z.string().min(1).max(64).optional().nullable(),
+    captainUserId: z.number().int().positive().optional().nullable(),
+    viceCaptainUserId: z.number().int().positive().optional().nullable(),
+    courtCaptainUserId: z.number().int().positive().optional().nullable(),
+});

--- a/BE/src/modules/team-registrations/team-registration.service.ts
+++ b/BE/src/modules/team-registrations/team-registration.service.ts
@@ -1,0 +1,505 @@
+import { Repository } from "typeorm";
+import { AppDataSource } from "../../db/data-source.js";
+import { TeamRegistration, RosterEntry } from "./team-registration.entity.js";
+import { Seasons } from "../seasons/season.entity.js";
+import { Teams } from "../teams/team.entity.js";
+import { Players } from "../players/player.entity.js";
+import { User } from "../user/user.entity.js";
+import { RegionService } from "../regions/region.service.js";
+import { RegionCode } from "../regions/region.entity.js";
+import { UserService } from "../user/user.service.js";
+import { normalizeRobloxUsername } from "../../middleware/authValidation.js";
+import { NotFoundError } from "../../errors/NotFoundError.js";
+import { ConflictError } from "../../errors/ConflictError.js";
+import { UnauthorizedError } from "../../errors/UnauthorizedError.js";
+import type {
+    CreateTeamRegistrationDto,
+    UpdateTeamRegistrationDto,
+    ResolveRegistrationDto,
+} from "./team-registration.schema.js";
+
+export interface NameConflict {
+    type: "name";
+    teamName: string;
+    existingTeamId: number;
+}
+
+export interface PlayerConflict {
+    type: "player";
+    roblox: string;
+    existingTeamId: number;
+    existingTeamName: string;
+    playerId: number;
+}
+
+export type RegistrationConflict = NameConflict | PlayerConflict;
+
+function normalizeRoster(roster: RosterEntry[]): RosterEntry[] {
+    return roster.map((r) => ({
+        discord: r.discord.trim(),
+        roblox: normalizeRobloxUsername(r.roblox),
+    }));
+}
+
+export class TeamRegistrationService {
+    private repo: Repository<TeamRegistration>;
+    private seasonRepo: Repository<Seasons>;
+    private teamRepo: Repository<Teams>;
+    private playerRepo: Repository<Players>;
+    private userRepo: Repository<User>;
+    private regionService = new RegionService();
+    private userService = new UserService();
+
+    constructor() {
+        this.repo = AppDataSource.getRepository(TeamRegistration);
+        this.seasonRepo = AppDataSource.getRepository(Seasons);
+        this.teamRepo = AppDataSource.getRepository(Teams);
+        this.playerRepo = AppDataSource.getRepository(Players);
+        this.userRepo = AppDataSource.getRepository(User);
+    }
+
+    private async openSeasonForRegion(regionCode: RegionCode): Promise<{ season: Seasons; regionId: number }> {
+        const region = await this.regionService.requireRegionByCode(regionCode);
+        const open = await this.seasonRepo.find({
+            where: { regionId: region.id, registrationsOpen: true },
+            order: { seasonNumber: "DESC" },
+        });
+        if (open.length === 0) {
+            throw new ConflictError("Team registrations are not open for this region");
+        }
+        if (open.length > 1) {
+            throw new ConflictError("Multiple seasons have registrations open; ask an admin to fix this");
+        }
+        return { season: open[0], regionId: region.id };
+    }
+
+    async submit(userId: number, dto: CreateTeamRegistrationDto): Promise<TeamRegistration> {
+        const { season, regionId } = await this.openSeasonForRegion(dto.region);
+
+        const active = await this.repo.findOne({
+            where: [
+                { submittedByUserId: userId, seasonId: season.id, status: "pending" },
+                { submittedByUserId: userId, seasonId: season.id, status: "conflict" },
+                { submittedByUserId: userId, seasonId: season.id, status: "accepted" },
+            ],
+        });
+        if (active?.status === "accepted") {
+            throw new ConflictError("You already have an accepted team in this region/season");
+        }
+        if (active) {
+            throw new ConflictError("You already have an active application for this region/season");
+        }
+
+        const row = new TeamRegistration();
+        row.submittedByUserId = userId;
+        row.regionId = regionId;
+        row.seasonId = season.id;
+        row.teamName = dto.teamName.trim();
+        row.hexColor = dto.hexColor;
+        row.brickColor = dto.brickColor.trim();
+        row.captainDiscord = dto.captainDiscord.trim();
+        row.captainRoblox = normalizeRobloxUsername(dto.captainRoblox);
+        row.viceDiscord = dto.viceDiscord.trim();
+        row.viceRoblox = normalizeRobloxUsername(dto.viceRoblox);
+        row.roster = normalizeRoster(dto.roster);
+        row.agreeCivilScheduling = true;
+        row.confidentWillParticipate = true;
+        row.priorLeagueExperience = dto.priorLeagueExperience?.trim() || null;
+        row.logoJerseyAck = true;
+        row.status = "pending";
+
+        return await this.repo.save(row);
+    }
+
+    async updatePending(userId: number, id: number, dto: UpdateTeamRegistrationDto): Promise<TeamRegistration> {
+        const row = await this.requireOwned(userId, id);
+        if (row.status !== "pending") {
+            throw new ConflictError("Only pending applications can be edited");
+        }
+
+        if (dto.teamName !== undefined) row.teamName = dto.teamName.trim();
+        if (dto.hexColor !== undefined) row.hexColor = dto.hexColor;
+        if (dto.brickColor !== undefined) row.brickColor = dto.brickColor.trim();
+        if (dto.captainDiscord !== undefined) row.captainDiscord = dto.captainDiscord.trim();
+        if (dto.captainRoblox !== undefined) row.captainRoblox = normalizeRobloxUsername(dto.captainRoblox);
+        if (dto.viceDiscord !== undefined) row.viceDiscord = dto.viceDiscord.trim();
+        if (dto.viceRoblox !== undefined) row.viceRoblox = normalizeRobloxUsername(dto.viceRoblox);
+        if (dto.roster !== undefined) row.roster = normalizeRoster(dto.roster);
+        if (dto.priorLeagueExperience !== undefined) {
+            row.priorLeagueExperience = dto.priorLeagueExperience?.trim() || null;
+        }
+        if (dto.agreeCivilScheduling !== undefined) row.agreeCivilScheduling = dto.agreeCivilScheduling;
+        if (dto.confidentWillParticipate !== undefined) {
+            row.confidentWillParticipate = dto.confidentWillParticipate;
+        }
+        if (dto.logoJerseyAck !== undefined) row.logoJerseyAck = dto.logoJerseyAck;
+
+        return await this.repo.save(row);
+    }
+
+    async withdraw(userId: number, id: number): Promise<void> {
+        const row = await this.requireOwned(userId, id);
+        if (row.status !== "pending" && row.status !== "conflict") {
+            throw new ConflictError("Only pending or conflict applications can be withdrawn");
+        }
+        await this.repo.remove(row);
+    }
+
+    private async requireOwned(userId: number, id: number): Promise<TeamRegistration> {
+        const row = await this.repo.findOne({ where: { id } });
+        if (!row) throw new NotFoundError("Registration not found");
+        if (row.submittedByUserId !== userId) throw new UnauthorizedError("Not your registration");
+        return row;
+    }
+
+    async list(filters: {
+        regionId?: number;
+        region?: RegionCode;
+        seasonId?: number;
+        status?: string;
+    }): Promise<TeamRegistration[]> {
+        let regionId = filters.regionId;
+        if (!regionId && filters.region) {
+            regionId = (await this.regionService.requireRegionByCode(filters.region)).id;
+        }
+
+        const qb = this.repo
+            .createQueryBuilder("r")
+            .leftJoinAndSelect("r.region", "region")
+            .leftJoinAndSelect("r.season", "season")
+            .leftJoinAndSelect("r.submittedBy", "submittedBy")
+            .orderBy("CASE WHEN r.status = 'accepted' THEN 0 ELSE 1 END", "ASC")
+            .addOrderBy("r.createdAt", "ASC");
+
+        if (regionId) qb.andWhere("r.regionId = :regionId", { regionId });
+        if (filters.seasonId) qb.andWhere("r.seasonId = :seasonId", { seasonId: filters.seasonId });
+        if (filters.status) qb.andWhere("r.status = :status", { status: filters.status });
+
+        return qb.getMany();
+    }
+
+    toPublicDto(row: TeamRegistration) {
+        return {
+            id: row.id,
+            teamName: row.teamName,
+            captainDiscord: row.captainDiscord,
+            captainRoblox: row.captainRoblox,
+            status: row.status,
+            regionId: row.regionId,
+            seasonId: row.seasonId,
+            region: row.region,
+            season: row.season
+                ? {
+                      id: row.season.id,
+                      seasonNumber: row.season.seasonNumber,
+                      startDate: row.season.startDate,
+                      maxTeams: row.season.maxTeams,
+                      registrationsOpen: row.season.registrationsOpen,
+                  }
+                : undefined,
+            createdAt: row.createdAt,
+        };
+    }
+
+    toDetailDto(row: TeamRegistration, includeAdmin = false) {
+        const base = {
+            ...this.toPublicDto(row),
+            hexColor: row.hexColor,
+            brickColor: row.brickColor,
+            viceDiscord: row.viceDiscord,
+            viceRoblox: row.viceRoblox,
+            roster: row.roster,
+            agreeCivilScheduling: row.agreeCivilScheduling,
+            confidentWillParticipate: row.confidentWillParticipate,
+            priorLeagueExperience: row.priorLeagueExperience,
+            logoJerseyAck: row.logoJerseyAck,
+            createdTeamId: row.createdTeamId,
+            captainLinkPending: row.captainLinkPending,
+            submittedByUserId: row.submittedByUserId,
+            submittedBy: row.submittedBy
+                ? { id: row.submittedBy.id, username: row.submittedBy.username }
+                : undefined,
+        };
+        if (includeAdmin) {
+            return { ...base, conflictPayload: row.conflictPayload };
+        }
+        return base;
+    }
+
+    async getById(id: number): Promise<TeamRegistration> {
+        const row = await this.repo.findOne({
+            where: { id },
+            relations: ["region", "season", "submittedBy", "createdTeam"],
+        });
+        if (!row) throw new NotFoundError("Registration not found");
+        return row;
+    }
+
+    async summary(region?: RegionCode, seasonId?: number) {
+        let regionId: number | undefined;
+        if (region) regionId = (await this.regionService.requireRegionByCode(region)).id;
+
+        let season: Seasons | null = null;
+        if (seasonId) {
+            season = await this.seasonRepo.findOne({ where: { id: seasonId } });
+        } else if (regionId) {
+            season = await this.seasonRepo.findOne({
+                where: { regionId, registrationsOpen: true },
+                order: { seasonNumber: "DESC" },
+            });
+            if (!season) {
+                season = await this.seasonRepo.findOne({
+                    where: { regionId },
+                    order: { seasonNumber: "DESC" },
+                });
+            }
+        }
+
+        if (!season) {
+            return { accepted: 0, spotsLeft: null, capacity: null, seasonId: null };
+        }
+
+        const accepted = await this.repo.count({
+            where: { seasonId: season.id, status: "accepted" },
+        });
+        const capacity = season.maxTeams;
+        const spotsLeft = capacity != null ? Math.max(0, capacity - accepted) : null;
+        return {
+            accepted,
+            spotsLeft,
+            capacity,
+            seasonId: season.id,
+            startDate: season.startDate,
+            registrationsOpen: season.registrationsOpen,
+            seasonNumber: season.seasonNumber,
+        };
+    }
+
+    async detectConflicts(
+        seasonId: number,
+        regionId: number,
+        teamName: string,
+        roster: RosterEntry[],
+        excludeTeamId?: number | null
+    ): Promise<RegistrationConflict[]> {
+        const conflicts: RegistrationConflict[] = [];
+
+        const nameTeam = await this.teamRepo.findOne({
+            where: { name: teamName, regionId, season: { id: seasonId } },
+            relations: ["season"],
+        });
+        if (nameTeam && nameTeam.id !== excludeTeamId) {
+            conflicts.push({ type: "name", teamName, existingTeamId: nameTeam.id });
+        }
+
+        for (const entry of roster) {
+            const roblox = normalizeRobloxUsername(entry.roblox);
+            const player = await this.playerRepo.findOne({
+                where: { robloxUsername: roblox },
+                relations: ["teams", "teams.season"],
+            });
+            if (!player?.teams?.length) continue;
+            const other = player.teams.find(
+                (t) => t.season?.id === seasonId && t.id !== excludeTeamId
+            );
+            if (other) {
+                conflicts.push({
+                    type: "player",
+                    roblox,
+                    existingTeamId: other.id,
+                    existingTeamName: other.name,
+                    playerId: player.id,
+                });
+            }
+        }
+
+        return conflicts;
+    }
+
+    async tryAccept(
+        id: number,
+        adminId: number,
+        options?: { teamName?: string; exclusions?: Set<string>; transfers?: Set<string> }
+    ): Promise<{ ok: true; registration: TeamRegistration; team: Teams } | { ok: false; conflicts: RegistrationConflict[]; registration: TeamRegistration }> {
+        const row = await this.getById(id);
+        if (row.status === "accepted") throw new ConflictError("Already accepted");
+        if (row.status === "denied") throw new ConflictError("Registration is denied");
+
+        let roster = [...row.roster];
+        const teamName = options?.teamName?.trim() || row.teamName;
+
+        if (options?.exclusions?.size) {
+            roster = roster.filter((r) => !options.exclusions!.has(normalizeRobloxUsername(r.roblox)));
+        }
+        if (roster.length < 10) {
+            throw new ConflictError("Roster must have at least 10 players after exclusions");
+        }
+
+        const conflicts = await this.detectConflicts(row.seasonId, row.regionId, teamName, roster, row.createdTeamId);
+        const remaining = conflicts.filter((c) => {
+            if (c.type === "player" && options?.transfers?.has(c.roblox)) return false;
+            if (c.type === "player" && options?.exclusions?.has(c.roblox)) return false;
+            if (c.type === "name" && options?.teamName && options.teamName.trim() !== row.teamName) {
+                return c.teamName === options.teamName.trim();
+            }
+            return true;
+        });
+
+        // Re-detect after applying transfer intent conceptually
+        const effectiveConflicts: RegistrationConflict[] = [];
+        for (const c of conflicts) {
+            if (c.type === "name") {
+                if (options?.teamName && normalizeRobloxUsername(options.teamName) !== normalizeRobloxUsername(row.teamName)) {
+                    const still = await this.teamRepo.findOne({
+                        where: { name: teamName, regionId: row.regionId, season: { id: row.seasonId } },
+                    });
+                    if (still) effectiveConflicts.push({ type: "name", teamName, existingTeamId: still.id });
+                } else {
+                    effectiveConflicts.push(c);
+                }
+            } else if (c.type === "player") {
+                if (options?.exclusions?.has(c.roblox)) continue;
+                if (options?.transfers?.has(c.roblox)) continue;
+                effectiveConflicts.push(c);
+            }
+        }
+
+        if (effectiveConflicts.length > 0) {
+            row.status = "conflict";
+            row.conflictPayload = { conflicts: effectiveConflicts };
+            if (options?.teamName) row.teamName = teamName;
+            await this.repo.save(row);
+            return { ok: false, conflicts: effectiveConflicts, registration: row };
+        }
+
+        // Apply transfers
+        if (options?.transfers?.size) {
+            for (const roblox of options.transfers) {
+                const player = await this.playerRepo.findOne({
+                    where: { robloxUsername: roblox },
+                    relations: ["teams", "teams.season"],
+                });
+                if (!player) continue;
+                player.teams = (player.teams || []).filter((t) => t.season?.id !== row.seasonId);
+                await this.playerRepo.save(player);
+            }
+        }
+
+        if (options?.teamName) row.teamName = teamName;
+        row.roster = roster;
+
+        const team = new Teams();
+        team.name = row.teamName;
+        team.hexColor = row.hexColor;
+        team.brickColor = row.brickColor;
+        team.regionId = row.regionId;
+        team.season = row.season;
+        team.captainEditEnabled = true;
+        team.placement = "Didnt make playoffs";
+
+        const linkedCaptain = await this.userRepo.findOne({
+            where: { robloxUsername: row.captainRoblox },
+        });
+        if (linkedCaptain) {
+            team.captainUserId = linkedCaptain.id;
+            row.captainLinkPending = false;
+        } else {
+            team.captainUserId = row.submittedByUserId;
+            row.captainLinkPending = true;
+        }
+
+        const players: Players[] = [];
+        for (const entry of roster) {
+            let player = await this.playerRepo.findOne({
+                where: { robloxUsername: entry.roblox },
+                relations: ["teams"],
+            });
+            if (!player) {
+                player = new Players();
+                player.name = entry.roblox;
+                player.robloxUsername = entry.roblox;
+                player.discordUsername = entry.discord;
+                player.position = "N/A";
+                player.teams = [];
+            } else {
+                player.discordUsername = entry.discord;
+                if (!player.teams) player.teams = [];
+            }
+            const linkedUser = await this.userRepo.findOne({ where: { robloxUsername: entry.roblox } });
+            if (linkedUser) {
+                player.userId = linkedUser.id;
+                player.robloxUserId = linkedUser.robloxUserId;
+            }
+            players.push(await this.playerRepo.save(player));
+        }
+
+        team.players = players;
+        const savedTeam = await this.teamRepo.save(team);
+
+        row.status = "accepted";
+        row.createdTeamId = savedTeam.id;
+        row.conflictPayload = null;
+        await this.repo.save(row);
+
+        const captainId = team.captainUserId!;
+        await this.userService.promoteRoleIfUser(captainId, "captain", adminId);
+
+        // TODO: Google Sheets sync (name, brick, hex, region) when sheet exists
+
+        return { ok: true, registration: row, team: savedTeam };
+    }
+
+    async resolve(id: number, adminId: number, dto: ResolveRegistrationDto) {
+        if (dto.decision === "pending") {
+            const row = await this.getById(id);
+            row.status = "pending";
+            row.conflictPayload = null;
+            return { registration: await this.repo.save(row) };
+        }
+        if (dto.decision === "denied") {
+            return { registration: await this.deny(id) };
+        }
+
+        const exclusions = new Set(
+            (dto.players || []).filter((p) => p.action === "exclude").map((p) => normalizeRobloxUsername(p.roblox))
+        );
+        const transfers = new Set(
+            (dto.players || []).filter((p) => p.action === "transfer").map((p) => normalizeRobloxUsername(p.roblox))
+        );
+
+        return this.tryAccept(id, adminId, {
+            teamName: dto.teamName,
+            exclusions,
+            transfers,
+        });
+    }
+
+    async deny(id: number): Promise<TeamRegistration> {
+        const row = await this.getById(id);
+        if (row.status === "accepted") {
+            throw new ConflictError("Use revoke while registrations are open to undo an accepted application");
+        }
+        row.status = "denied";
+        row.conflictPayload = null;
+        return await this.repo.save(row);
+    }
+
+    async revoke(id: number): Promise<TeamRegistration> {
+        const row = await this.getById(id);
+        if (row.status !== "accepted") {
+            throw new ConflictError("Only accepted registrations can be revoked");
+        }
+        const season = await this.seasonRepo.findOne({ where: { id: row.seasonId } });
+        if (!season?.registrationsOpen) {
+            throw new ConflictError(
+                "Application process is closed; leave the team archived for season records"
+            );
+        }
+
+        row.status = "denied";
+        // Keep created team for history but clear link optional — plan says prefer status change;
+        // leave team as-is in DB for archive during open period we still deny the registration.
+        await this.repo.save(row);
+        return row;
+    }
+}

--- a/BE/src/modules/teams/team.controller.ts
+++ b/BE/src/modules/teams/team.controller.ts
@@ -200,4 +200,26 @@ export class TeamController {
             next(error);
         }
     };
+
+    staffUpdate = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const team = await this.teamService.staffUpdateTeam(parseInt(req.params.id), req.user.id, req.body);
+            res.json(this.teamService.enrichTeamWithCanEdit(team, req.user.id));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    adminFlags = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const team = await this.teamService.adminPatchTeamFlags(parseInt(req.params.id), req.body);
+            res.json(team);
+        } catch (error) {
+            next(error);
+        }
+    };
 }

--- a/BE/src/modules/teams/team.routes.ts
+++ b/BE/src/modules/teams/team.routes.ts
@@ -4,6 +4,7 @@ import { authenticateCombined } from '../../middleware/combinedAuth.js';
 import { authorizeRoles } from '../../middleware/authorizeRoles.js';
 import { createTeamSchema, updateTeamSchema } from './teams.schema.js';
 import { TeamController } from './team.controller.js';
+import { staffTeamUpdateSchema, adminTeamFlagsSchema } from '../team-registrations/team-registration.schema.js';
 
 export function registerTeamRoutes(app: Application): void {
     const router = Router();
@@ -23,6 +24,23 @@ export function registerTeamRoutes(app: Application): void {
     router.get('/name/:name/players', teamController.getTeamPlayersByName);
     router.get('/:teamId/players', teamController.getTeamPlayers);
     router.get('/name/:name', teamController.getTeamsByName.bind(teamController));
+
+    // Captain / VC / CC staff edit
+    router.patch(
+        '/:id/staff',
+        authenticateCombined,
+        validate(staffTeamUpdateSchema),
+        teamController.staffUpdate
+    );
+
+    // Admin flags / staff override
+    router.patch(
+        '/:id/flags',
+        authenticateCombined,
+        authorizeRoles("admin", "superadmin"),
+        validate(adminTeamFlagsSchema),
+        teamController.adminFlags
+    );
     
     // UPDATE/DELETE routes - PROTECTED
     router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updateTeamSchema), teamController.updateTeam);

--- a/BE/src/modules/teams/team.service.ts
+++ b/BE/src/modules/teams/team.service.ts
@@ -9,10 +9,15 @@ import { MultipleGamesNotFoundError } from '../../errors/MultipleGamesNotFoundEr
 import { MultiplePlayersNotFoundError } from '../../errors/MultiplePlayersNotFoundError.js';
 import { DuplicateError } from '../../errors/DuplicateError.js';
 import { NotFoundError } from '../../errors/NotFoundError.js';
+import { ConflictError } from '../../errors/ConflictError.js';
+import { UnauthorizedError } from '../../errors/UnauthorizedError.js';
 import { CreateTeamDto, UpdateTeamDto, CreateMultipleTeamsDto } from './teams.schema.js';
 import { PaginationParams, SortParams } from '../../utils/pagination.js';
 import { RegionService } from '../regions/region.service.js';
 import { RegionCode } from '../regions/region.entity.js';
+import { User } from '../user/user.entity.js';
+import { UserService } from '../user/user.service.js';
+import { normalizeRobloxUsername } from '../../middleware/authValidation.js';
 
 export interface TeamFilters {
     search?: string;
@@ -507,5 +512,180 @@ export class TeamService {
         }
 
         await this.teamRepository.remove(team);
+    }
+
+    async getTeamForStaff(id: number): Promise<Teams> {
+        const team = await this.teamRepository.findOne({
+            where: { id },
+            relations: ["season", "players", "captainUser", "viceCaptainUser", "courtCaptainUser", "region"],
+        });
+        if (!team) throw new NotFoundError(`Team with ID ${id} not found`);
+        return team;
+    }
+
+    canStaffEdit(team: Teams, userId: number): {
+        allowed: boolean;
+        role: "captain" | "vice_captain" | "court_captain" | null;
+        reason?: string;
+    } {
+        if (!team.season?.captainEditEnabled) {
+            return { allowed: false, role: null, reason: "Captain editing is disabled for this season" };
+        }
+        if (!team.captainEditEnabled) {
+            return { allowed: false, role: null, reason: "Captain editing is disabled for this team" };
+        }
+        if (team.captainUserId === userId) return { allowed: true, role: "captain" };
+        if (team.viceCaptainUserId === userId) return { allowed: true, role: "vice_captain" };
+        if (team.courtCaptainUserId === userId) return { allowed: true, role: "court_captain" };
+        return { allowed: false, role: null, reason: "You are not staff on this team" };
+    }
+
+    private async assertLinkedRosterUser(team: Teams, userId: number): Promise<User> {
+        const userRepo = AppDataSource.getRepository(User);
+        const user = await userRepo.findOne({ where: { id: userId } });
+        if (!user?.robloxUsername) {
+            throw new ConflictError("Target user must have a linked Roblox account");
+        }
+        const onRoster = (team.players || []).some(
+            (p) => p.robloxUsername === user.robloxUsername || p.userId === userId
+        );
+        if (!onRoster) {
+            throw new ConflictError("Target user must be on the team roster with a linked Roblox account");
+        }
+        return user;
+    }
+
+    async staffUpdateTeam(
+        teamId: number,
+        actorId: number,
+        body: {
+            name?: string;
+            hexColor?: string | null;
+            brickColor?: string | null;
+            logoUrl?: string | null;
+            roster?: { discord: string; roblox: string }[];
+            captainUserId?: number | null;
+            viceCaptainUserId?: number | null;
+            courtCaptainUserId?: number | null;
+        }
+    ): Promise<Teams> {
+        const team = await this.getTeamForStaff(teamId);
+        const gate = this.canStaffEdit(team, actorId);
+        if (!gate.allowed || !gate.role) {
+            throw new UnauthorizedError(gate.reason || "Forbidden");
+        }
+
+        const role = gate.role;
+
+        if (body.name !== undefined) {
+            if (role !== "captain") throw new UnauthorizedError("Only the captain can rename the team");
+            const clash = await this.teamRepository.findOne({
+                where: { name: body.name.trim(), regionId: team.regionId, season: { id: team.season.id } },
+            });
+            if (clash && clash.id !== team.id) {
+                throw new ConflictError(`A team named "${body.name}" already exists in this season`);
+            }
+            team.name = body.name.trim();
+        }
+
+        if (body.hexColor !== undefined || body.brickColor !== undefined || body.logoUrl !== undefined) {
+            if (body.hexColor !== undefined) team.hexColor = body.hexColor;
+            if (body.brickColor !== undefined) team.brickColor = body.brickColor;
+            if (body.logoUrl !== undefined) team.logoUrl = body.logoUrl ?? undefined;
+        }
+
+        if (body.roster !== undefined) {
+            if (body.roster.length < 10) throw new ConflictError("Roster must have at least 10 players");
+            const players: Players[] = [];
+            for (const entry of body.roster) {
+                const roblox = normalizeRobloxUsername(entry.roblox);
+                const existing = await this.playerRepository.findOne({
+                    where: { robloxUsername: roblox },
+                    relations: ["teams", "teams.season"],
+                });
+                if (existing?.teams?.some((t) => t.season?.id === team.season.id && t.id !== team.id)) {
+                    throw new ConflictError(`Player ${roblox} is already on another team this season`);
+                }
+                let player = existing;
+                if (!player) {
+                    player = new Players();
+                    player.name = roblox;
+                    player.robloxUsername = roblox;
+                    player.discordUsername = entry.discord.trim();
+                    player.position = "N/A";
+                    player.teams = [];
+                } else {
+                    player.discordUsername = entry.discord.trim();
+                }
+                players.push(await this.playerRepository.save(player));
+            }
+            team.players = players;
+        }
+
+        const userService = new UserService();
+
+        if (body.captainUserId !== undefined) {
+            if (role !== "captain") throw new UnauthorizedError("Only the captain can transfer captaincy");
+            if (body.captainUserId != null) {
+                await this.assertLinkedRosterUser(team, body.captainUserId);
+                team.captainUserId = body.captainUserId;
+                await userService.promoteRoleIfUser(body.captainUserId, "captain", actorId);
+            }
+        }
+
+        if (body.viceCaptainUserId !== undefined) {
+            if (role !== "captain") throw new UnauthorizedError("Only the captain can assign vice captain");
+            if (body.viceCaptainUserId != null) {
+                await this.assertLinkedRosterUser(team, body.viceCaptainUserId);
+                team.viceCaptainUserId = body.viceCaptainUserId;
+                await userService.promoteRoleIfUser(body.viceCaptainUserId, "vice_captain", actorId);
+            } else {
+                team.viceCaptainUserId = null;
+            }
+        }
+
+        if (body.courtCaptainUserId !== undefined) {
+            if (role !== "captain" && role !== "vice_captain") {
+                throw new UnauthorizedError("Only captain or vice captain can assign court captain");
+            }
+            if (body.courtCaptainUserId != null) {
+                await this.assertLinkedRosterUser(team, body.courtCaptainUserId);
+                team.courtCaptainUserId = body.courtCaptainUserId;
+                await userService.promoteRoleIfUser(body.courtCaptainUserId, "court_captain", actorId);
+            } else {
+                team.courtCaptainUserId = null;
+            }
+        }
+
+        await this.teamRepository.save(team);
+        return this.getTeamForStaff(teamId);
+    }
+
+    async adminPatchTeamFlags(
+        teamId: number,
+        body: {
+            captainEditEnabled?: boolean;
+            hexColor?: string | null;
+            brickColor?: string | null;
+            captainUserId?: number | null;
+            viceCaptainUserId?: number | null;
+            courtCaptainUserId?: number | null;
+        }
+    ): Promise<Teams> {
+        const team = await this.getTeamForStaff(teamId);
+        if (body.captainEditEnabled !== undefined) team.captainEditEnabled = body.captainEditEnabled;
+        if (body.hexColor !== undefined) team.hexColor = body.hexColor;
+        if (body.brickColor !== undefined) team.brickColor = body.brickColor;
+        if (body.captainUserId !== undefined) team.captainUserId = body.captainUserId;
+        if (body.viceCaptainUserId !== undefined) team.viceCaptainUserId = body.viceCaptainUserId;
+        if (body.courtCaptainUserId !== undefined) team.courtCaptainUserId = body.courtCaptainUserId;
+        await this.teamRepository.save(team);
+        return this.getTeamForStaff(teamId);
+    }
+
+    enrichTeamWithCanEdit(team: Teams, userId?: number) {
+        if (!userId) return { ...team, captainCanEdit: false, staffRole: null };
+        const gate = this.canStaffEdit(team, userId);
+        return { ...team, captainCanEdit: gate.allowed, staffRole: gate.role };
     }
 }


### PR DESCRIPTION
## Summary
- Add `/api/team-registrations` submit/edit/withdraw/list/accept/resolve/deny/revoke
- Wire season `registrationsOpen` / `captainEditEnabled` / `maxTeams` updates
- Add `PATCH /api/teams/:id/staff` and admin `/flags` with captain/VC/CC permission matrix

## Test plan
- [ ] Open registrations on a season, submit an application as a logged-in user
- [ ] Admin accept with no conflicts creates a team and promotes captain
- [ ] Conflict path returns 409 and resolve rename/transfer/exclude works
- [ ] Revoke only while `registrationsOpen`; staff edit respects season then team flags

**Base:** `feat/roblox-sso`