### PR TITLE
Add team application portal UI

### DIFF
--- a/BE/src/modules/stats/stat.schema.ts
+++ b/BE/src/modules/stats/stat.schema.ts
@@ -31,6 +31,6 @@ export const createStatByNameSchema = createStatSchema
   });
 
 export type CreateStatDto = z.infer<typeof createStatSchema>;
-export type UpdateStatDto = z.infer<typeof createStatSchema.partial()>;
+export type UpdateStatDto = z.infer<typeof updateStatSchema>;
 export type CreateStatByNameDto = z.infer<typeof createStatByNameSchema>;
 

--- a/BE/src/modules/team-registrations/team-registration.schema.ts
+++ b/BE/src/modules/team-registrations/team-registration.schema.ts
@@ -6,41 +6,63 @@ const rosterEntrySchema = z.object({
     roblox: z.string().min(1),
 });
 
-export const createTeamRegistrationSchema = z
-    .object({
-        region: z.enum(REGION_CODES),
-        teamName: z.string().min(1).max(64),
-        hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/, { message: "hexColor must be #RRGGBB" }),
-        brickColor: z.string().min(1).max(64),
-        captainDiscord: z.string().min(1),
-        captainRoblox: z.string().min(1),
-        viceDiscord: z.string().min(1),
-        viceRoblox: z.string().min(1),
-        roster: z.array(rosterEntrySchema).min(10),
-        agreeCivilScheduling: z.literal(true),
-        confidentWillParticipate: z.literal(true),
-        priorLeagueExperience: z.string().max(2000).optional().nullable(),
-        logoJerseyAck: z.literal(true),
-    })
+const teamRegistrationFields = z.object({
+    region: z.enum(REGION_CODES),
+    teamName: z.string().min(1).max(64),
+    hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/, { message: "hexColor must be #RRGGBB" }),
+    brickColor: z.string().min(1).max(64),
+    captainDiscord: z.string().min(1),
+    captainRoblox: z.string().min(1),
+    viceDiscord: z.string().min(1),
+    viceRoblox: z.string().min(1),
+    roster: z.array(rosterEntrySchema).min(10),
+    agreeCivilScheduling: z.literal(true),
+    confidentWillParticipate: z.literal(true),
+    priorLeagueExperience: z.string().max(2000).optional().nullable(),
+    logoJerseyAck: z.literal(true),
+});
+
+function refineTeamRegistrationRoster(
+    data: {
+        roster: Array<{ roblox: string }>;
+        captainRoblox: string;
+        viceRoblox: string;
+    },
+    ctx: z.RefinementCtx
+): void {
+    const robloxes = data.roster.map((r) => r.roblox.trim().toLowerCase());
+    const unique = new Set(robloxes);
+    if (unique.size !== robloxes.length) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Duplicate Roblox usernames in roster", path: ["roster"] });
+    }
+    const captain = data.captainRoblox.trim().toLowerCase();
+    const vice = data.viceRoblox.trim().toLowerCase();
+    if (!robloxes.includes(captain)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include captain Roblox", path: ["roster"] });
+    }
+    if (!robloxes.includes(vice)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include vice Roblox", path: ["roster"] });
+    }
+}
+
+export const createTeamRegistrationSchema = teamRegistrationFields.superRefine(refineTeamRegistrationRoster);
+
+export const updateTeamRegistrationSchema = teamRegistrationFields
+    .partial()
+    .omit({ region: true })
     .superRefine((data, ctx) => {
-        const robloxes = data.roster.map((r) => r.roblox.trim().toLowerCase());
-        const unique = new Set(robloxes);
-        if (unique.size !== robloxes.length) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Duplicate Roblox usernames in roster", path: ["roster"] });
-        }
-        const captain = data.captainRoblox.trim().toLowerCase();
-        const vice = data.viceRoblox.trim().toLowerCase();
-        if (!robloxes.includes(captain)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include captain Roblox", path: ["roster"] });
-        }
-        if (!robloxes.includes(vice)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include vice Roblox", path: ["roster"] });
-        }
+        // Only enforce roster inclusion rules when enough fields are present to check.
+        if (!data.roster || !data.captainRoblox || !data.viceRoblox) return;
+        refineTeamRegistrationRoster(
+            {
+                roster: data.roster,
+                captainRoblox: data.captainRoblox,
+                viceRoblox: data.viceRoblox,
+            },
+            ctx
+        );
     });
 
-export const updateTeamRegistrationSchema = createTeamRegistrationSchema.partial().omit({
-    region: true,
-});
 
 export const resolveRegistrationSchema = z.object({
     decision: z.enum(["pending", "denied"]).optional(),

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -45,6 +45,10 @@ const AwardsPage        = lazy(() => import("./components/portal/AwardsPage"));
 const CreateArticle     = lazy(() => import("./components/CreateArticle"));
 const ArticlesPage      = lazy(() => import("./components/portal/ArticlesPage"));
 const ApplicationsPage  = lazy(() => import("./components/portal/ApplicationsPage"));
+const RegistrationsHubPage = lazy(() => import("./components/portal/RegistrationsHubPage"));
+const TeamRegistrations = lazy(() => import("./components/TeamRegistrations"));
+const TeamRegister = lazy(() => import("./components/TeamRegister"));
+const TeamRegistrationDetail = lazy(() => import("./components/TeamRegistrationDetail"));
 const StatsLeaderboard  = lazy(() => import("./components/StatsLeaderboard"));
 const FAQ               = lazy(() => import("./components/FAQ"));
 const RecordsPage       = lazy(() => import("./components/RecordsPage"));
@@ -69,6 +73,9 @@ const App: React.FC = () => (
           <Route path="/about" element={<About />} />
           <Route path="/players" element={<Players />} />
           <Route path="/teams" element={<Teams />} />
+          <Route path="/teams/registrations" element={<TeamRegistrations />} />
+          <Route path="/teams/registrations/:id" element={<TeamRegistrationDetail />} />
+          <Route path="/teams/register" element={<TeamRegister />} />
           <Route path="/teams/:teamName" element={<SingleTeam />} />
           <Route path="/games" element={<Games />} />
           <Route path="/games/:id" element={<SingleGame />} />
@@ -117,6 +124,7 @@ const App: React.FC = () => (
             <Route path="awards" element={<AwardsPage />} />
             <Route path="articles" element={<ArticlesPage />} />
             <Route path="applications" element={<ApplicationsPage />} />
+            <Route path="registrations" element={<RegistrationsHubPage />} />
           </Route>
         </Routes>
         </Suspense>

--- a/FE/src/components/Single/SingleTeam.tsx
+++ b/FE/src/components/Single/SingleTeam.tsx
@@ -6,6 +6,8 @@ import { useSingleTeam }                             from '../../hooks/allFetch'
 import "../../styles/SingleTeam.css";
 import SEO from "../SEO";
 import { formatGameStage } from "../../utils/gameLabels";
+import TeamStaffEdit from "../TeamStaffEdit";
+import "../../styles/TeamRegistrations.css";
 
 const SingleTeam: React.FC = () =>
 {
@@ -185,6 +187,8 @@ const SingleTeam: React.FC = () =>
             <p>Season: {team.season.seasonNumber ?? 'N/A'}</p>
             <p>Playoff Games Played: {team.games?.length ?? 0}</p>
             <p>Placement: {team.placement}</p>
+
+            <TeamStaffEdit team={team} />
 
             {/* Players Section */}
             <div className="players-list">

--- a/FE/src/components/TeamRegister.tsx
+++ b/FE/src/components/TeamRegister.tsx
@@ -1,0 +1,238 @@
+import React, { useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../context/authContext";
+import { useRegion } from "../context/regionContext";
+import { authFetch } from "../hooks/authFetch";
+import { BACKEND_URL } from "../constants/api";
+import { useRegistrationSummary } from "../hooks/useTeamRegistrations";
+import type { RegionCode, TeamRegistrationRosterEntry } from "../types/interfaces";
+import "../styles/TeamRegistrations.css";
+
+const emptyRoster = (): TeamRegistrationRosterEntry[] =>
+  Array.from({ length: 10 }, () => ({ discord: "", roblox: "" }));
+
+const TeamRegister: React.FC = () => {
+  const { isAuthenticated, loading: authLoading } = useAuth();
+  const { activeRegion } = useRegion();
+  const navigate = useNavigate();
+  const region = (activeRegion?.code || "na") as RegionCode;
+  const summary = useRegistrationSummary(region);
+
+  const [teamName, setTeamName] = useState("");
+  const [hexColor, setHexColor] = useState("#2D3C50");
+  const [brickColor, setBrickColor] = useState("");
+  const [captainDiscord, setCaptainDiscord] = useState("");
+  const [captainRoblox, setCaptainRoblox] = useState("");
+  const [viceDiscord, setViceDiscord] = useState("");
+  const [viceRoblox, setViceRoblox] = useState("");
+  const [roster, setRoster] = useState(emptyRoster);
+  const [agreeCivil, setAgreeCivil] = useState(false);
+  const [confident, setConfident] = useState(false);
+  const [experience, setExperience] = useState("");
+  const [logoAck, setLogoAck] = useState(false);
+  const [regionCode, setRegionCode] = useState<RegionCode>(region);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const startLabel = useMemo(() => {
+    if (summary?.startDate) {
+      try {
+        return new Date(summary.startDate).toLocaleDateString();
+      } catch {
+        return "TBD";
+      }
+    }
+    return "TBD";
+  }, [summary?.startDate]);
+
+  if (authLoading) return <div className="team-reg-form">Loading…</div>;
+
+  if (!isAuthenticated) {
+    return (
+      <div className="team-reg-form">
+        <h1>Register a team</h1>
+        <p>
+          You must be logged in to submit a team application.{" "}
+          <Link to="/login">Log in</Link> or <Link to="/signup">sign up</Link>.
+        </p>
+      </div>
+    );
+  }
+
+  const updateRoster = (index: number, field: "discord" | "roblox", value: string) => {
+    setRoster((prev) => prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)));
+  };
+
+  const syncCaptainViceIntoRoster = (next: TeamRegistrationRosterEntry[]) => {
+    const copy = [...next];
+    if (captainDiscord && captainRoblox) {
+      copy[0] = { discord: captainDiscord, roblox: captainRoblox };
+    }
+    if (viceDiscord && viceRoblox) {
+      copy[1] = { discord: viceDiscord, roblox: viceRoblox };
+    }
+    return copy;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setSubmitting(true);
+    try {
+      const body = {
+        region: regionCode,
+        teamName,
+        hexColor: hexColor.startsWith("#") ? hexColor : `#${hexColor}`,
+        brickColor,
+        captainDiscord,
+        captainRoblox,
+        viceDiscord,
+        viceRoblox,
+        roster: syncCaptainViceIntoRoster(roster),
+        agreeCivilScheduling: true as const,
+        confidentWillParticipate: true as const,
+        priorLeagueExperience: experience || null,
+        logoJerseyAck: true as const,
+      };
+
+      if (!agreeCivil || !confident || !logoAck) {
+        throw new Error("Please answer all required yes/no and acknowledgment questions");
+      }
+
+      const res = await authFetch(`${BACKEND_URL}/api/team-registrations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || data.message || "Submission failed");
+      setSuccess("Application submitted!");
+      navigate(`/teams/registrations/${data.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Submission failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="team-reg-form">
+      <div className="team-regs-nav">
+        <Link to="/teams">League teams</Link>
+        <span>·</span>
+        <Link to="/teams/registrations">Team registrations</Link>
+        <span>·</span>
+        <span className="team-regs-nav-active">Register a team</span>
+      </div>
+
+      <h1>Register your team</h1>
+      <p>Anyone with a site account can submit. Season start: {startLabel}.</p>
+      {error && <p className="form-error">{error}</p>}
+      {success && <p className="form-success">{success}</p>}
+
+      <form onSubmit={handleSubmit}>
+        <fieldset>
+          <legend>Eligibility</legend>
+          <label>
+            <input type="checkbox" checked={agreeCivil} onChange={(e) => setAgreeCivil(e.target.checked)} /> Do
+            you understand and agree to be civil and accommodating when scheduling matches?
+          </label>
+          <label>
+            <input type="checkbox" checked={confident} onChange={(e) => setConfident(e.target.checked)} /> This
+            season is set to start on {startLabel}. Are you confident the team will still participate by then?
+          </label>
+          <label>
+            Region
+            <select value={regionCode} onChange={(e) => setRegionCode(e.target.value as RegionCode)}>
+              <option value="na">NA</option>
+              <option value="eu">EU</option>
+              <option value="as">AS</option>
+            </select>
+          </label>
+          <label>
+            Prior competitive Roblox Volleyball leagues (optional)
+            <textarea value={experience} onChange={(e) => setExperience(e.target.value)} rows={3} />
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Team</legend>
+          <label>
+            Team name
+            <input value={teamName} onChange={(e) => setTeamName(e.target.value)} required />
+          </label>
+          <label>
+            Hex color
+            <input value={hexColor} onChange={(e) => setHexColor(e.target.value)} required pattern="#?[0-9A-Fa-f]{6}" />
+          </label>
+          <label>
+            Brick color
+            <input value={brickColor} onChange={(e) => setBrickColor(e.target.value)} required />
+          </label>
+          <label>
+            <input type="checkbox" checked={logoAck} onChange={(e) => setLogoAck(e.target.checked)} /> I will
+            prepare a logo &amp; jerseys if accepted to RVL
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Captain &amp; Vice</legend>
+          <label>
+            Captain Discord
+            <input value={captainDiscord} onChange={(e) => setCaptainDiscord(e.target.value)} required />
+          </label>
+          <label>
+            Captain Roblox
+            <input value={captainRoblox} onChange={(e) => setCaptainRoblox(e.target.value)} required />
+          </label>
+          <label>
+            Vice Discord
+            <input value={viceDiscord} onChange={(e) => setViceDiscord(e.target.value)} required />
+          </label>
+          <label>
+            Vice Roblox
+            <input value={viceRoblox} onChange={(e) => setViceRoblox(e.target.value)} required />
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Roster (minimum 10, including captain &amp; vice)</legend>
+          {roster.map((row, i) => (
+            <div className="roster-row" key={i}>
+              <input
+                placeholder={`Player ${i + 1} Discord`}
+                value={row.discord}
+                onChange={(e) => updateRoster(i, "discord", e.target.value)}
+                required
+              />
+              <input
+                placeholder={`Player ${i + 1} Roblox`}
+                value={row.roblox}
+                onChange={(e) => updateRoster(i, "roblox", e.target.value)}
+                required
+              />
+              {i >= 10 && (
+                <button type="button" onClick={() => setRoster((r) => r.filter((_, idx) => idx !== i))}>
+                  Remove
+                </button>
+              )}
+            </div>
+          ))}
+          <button type="button" onClick={() => setRoster((r) => [...r, { discord: "", roblox: "" }])}>
+            Add player
+          </button>
+        </fieldset>
+
+        <div className="form-actions">
+          <button type="submit" disabled={submitting}>
+            {submitting ? "Submitting…" : "Submit application"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default TeamRegister;

--- a/FE/src/components/TeamRegistrationDetail.tsx
+++ b/FE/src/components/TeamRegistrationDetail.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { authFetch } from "../hooks/authFetch";
+import { BACKEND_URL } from "../constants/api";
+import { useAuth } from "../context/authContext";
+import type { TeamRegistration } from "../types/interfaces";
+import "../styles/TeamRegistrations.css";
+
+const TeamRegistrationDetail: React.FC = () => {
+  const { id } = useParams();
+  const { user, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const [row, setRow] = useState<TeamRegistration | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await authFetch(`${BACKEND_URL}/api/team-registrations/${id}`);
+        if (!res.ok) throw new Error("Not found");
+        setRow(await res.json());
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [id]);
+
+  const withdraw = async () => {
+    if (!confirm("Withdraw this application?")) return;
+    const res = await authFetch(`${BACKEND_URL}/api/team-registrations/${id}`, { method: "DELETE" });
+    if (res.ok || res.status === 204) navigate("/teams/registrations");
+  };
+
+  if (loading) return <div className="team-reg-form">Loading…</div>;
+  if (error || !row) return <div className="team-reg-form form-error">{error || "Not found"}</div>;
+
+  const isOwner = isAuthenticated && user?.id === row.submittedByUserId;
+
+  return (
+    <div className="team-reg-form">
+      <Link to="/teams/registrations">← Back to registrations</Link>
+      <h1>{row.teamName}</h1>
+      <p className={`status-${row.status}`}>Status: {row.status}</p>
+      <p>
+        Captain: {row.captainDiscord} / {row.captainRoblox}
+      </p>
+      {row.viceDiscord && (
+        <p>
+          Vice: {row.viceDiscord} / {row.viceRoblox}
+        </p>
+      )}
+      {row.hexColor && (
+        <p>
+          Colors: <span style={{ color: row.hexColor }}>{row.hexColor}</span> / {row.brickColor}
+        </p>
+      )}
+      {row.priorLeagueExperience && <p>Experience: {row.priorLeagueExperience}</p>}
+      {row.roster && (
+        <>
+          <h2>Roster</h2>
+          <ul>
+            {row.roster.map((p, i) => (
+              <li key={i}>
+                {p.discord} — {p.roblox}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {isOwner && (row.status === "pending" || row.status === "conflict") && (
+        <button type="button" onClick={() => void withdraw()}>
+          Withdraw application
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default TeamRegistrationDetail;

--- a/FE/src/components/TeamRegistrations.tsx
+++ b/FE/src/components/TeamRegistrations.tsx
@@ -1,0 +1,124 @@
+import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useRegion } from "../context/regionContext";
+import { useAuth } from "../context/authContext";
+import { useTeamRegistrations, useRegistrationSummary } from "../hooks/useTeamRegistrations";
+import type { RegionCode, TeamRegistration } from "../types/interfaces";
+import "../styles/TeamRegistrations.css";
+
+const REGIONS: { code: RegionCode; label: string }[] = [
+  { code: "na", label: "NA" },
+  { code: "eu", label: "EU" },
+  { code: "as", label: "AS" },
+];
+
+const TeamRegistrations: React.FC = () => {
+  const { regions, setActiveRegion, activeRegion } = useRegion();
+  const { isAuthenticated } = useAuth();
+  const activeCode = (activeRegion?.code || "na") as RegionCode;
+  const { data, loading, error } = useTeamRegistrations({ region: activeCode });
+  const summary = useRegistrationSummary(activeCode);
+  const [selected, setSelected] = useState<TeamRegistration | null>(null);
+
+  const header = useMemo(() => {
+    if (!summary) return "Accepted teams";
+    if (summary.capacity != null) {
+      return `Accepted teams ${summary.accepted}/${summary.capacity}`;
+    }
+    return `Accepted teams ${summary.accepted}`;
+  }, [summary]);
+
+  const spotsLine =
+    summary?.spotsLeft != null
+      ? `${summary.spotsLeft} team spot${summary.spotsLeft === 1 ? "" : "s"} left…`
+      : null;
+
+  return (
+    <div className="team-regs-page">
+      <div className="team-regs-nav">
+        <Link to="/teams">League teams</Link>
+        <span aria-hidden="true">·</span>
+        <span className="team-regs-nav-active">Team registrations</span>
+        <span aria-hidden="true">·</span>
+        <Link to="/teams/register">{isAuthenticated ? "Register a team" : "Log in to register"}</Link>
+      </div>
+
+      <header className="team-regs-header">
+        <h1>Team registrations</h1>
+        <p>{header}</p>
+        {spotsLine && <p className="team-regs-spots">{spotsLine}</p>}
+      </header>
+
+      <div className="team-regs-region-tabs" role="tablist">
+        {REGIONS.map((r) => (
+          <button
+            key={r.code}
+            type="button"
+            role="tab"
+            aria-selected={activeCode === r.code}
+            className={activeCode === r.code ? "active" : undefined}
+            onClick={() => {
+              setSelected(null);
+              const match = regions.find((x) => x.code === r.code);
+              if (match) setActiveRegion(match);
+            }}
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+
+      {loading && <p>Loading…</p>}
+      {error && <p className="team-regs-error">{error}</p>}
+
+      {!loading && !error && (
+        <div className="team-regs-table-wrap">
+          <table className="team-regs-table">
+            <thead>
+              <tr>
+                <th>Team</th>
+                <th>Captain Discord</th>
+                <th>Captain Roblox</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((row) => (
+                <tr
+                  key={row.id}
+                  className={`status-${row.status} ${selected?.id === row.id ? "selected" : ""}`}
+                  onClick={() => setSelected(selected?.id === row.id ? null : row)}
+                >
+                  <td>{row.teamName}</td>
+                  <td>{row.captainDiscord}</td>
+                  <td>{row.captainRoblox}</td>
+                  <td>{row.status}</td>
+                </tr>
+              ))}
+              {data.length === 0 && (
+                <tr>
+                  <td colSpan={4}>No registrations yet for this region.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {selected && (
+        <div className="team-regs-detail">
+          <h2>{selected.teamName}</h2>
+          <p>
+            Status: <strong>{selected.status}</strong>
+          </p>
+          <p>
+            Captain: {selected.captainDiscord} / {selected.captainRoblox}
+          </p>
+          <Link to={`/teams/registrations/${selected.id}`}>View full details</Link>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TeamRegistrations;

--- a/FE/src/components/TeamStaffEdit.tsx
+++ b/FE/src/components/TeamStaffEdit.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from "react";
+import { useAuth } from "../context/authContext";
+import { authFetch } from "../hooks/authFetch";
+import { BACKEND_URL } from "../constants/api";
+import type { Team, Player } from "../types/interfaces";
+
+const TeamStaffEdit: React.FC<{ team: Team; onUpdated?: (t: Team) => void }> = ({ team, onUpdated }) => {
+  const { user, isAuthenticated } = useAuth();
+  const [meta, setMeta] = useState<{ captainCanEdit?: boolean; staffRole?: string | null } | null>(null);
+  const [name, setName] = useState(team.name);
+  const [hexColor, setHexColor] = useState(team.hexColor || "#2D3C50");
+  const [brickColor, setBrickColor] = useState(team.brickColor || "");
+  const [logoUrl, setLogoUrl] = useState(team.logoUrl || "");
+  const [roster, setRoster] = useState(
+    (team.players || []).map((p: Player) => ({
+      discord: p.discordUsername || "",
+      roblox: p.robloxUsername || p.name,
+    }))
+  );
+  const [message, setMessage] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated || !user) return;
+    void (async () => {
+      const res = await authFetch(`${BACKEND_URL}/api/teams/${team.id}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      // compute can-edit client-side from ownership if API doesn't enrich
+      const isStaff =
+        data.captainUserId === user.id ||
+        data.viceCaptainUserId === user.id ||
+        data.courtCaptainUserId === user.id;
+      const seasonOk = data.season?.captainEditEnabled !== false;
+      const teamOk = data.captainEditEnabled !== false;
+      setMeta({
+        captainCanEdit: Boolean(isStaff && seasonOk && teamOk),
+        staffRole:
+          data.captainUserId === user.id
+            ? "captain"
+            : data.viceCaptainUserId === user.id
+              ? "vice_captain"
+              : data.courtCaptainUserId === user.id
+                ? "court_captain"
+                : null,
+      });
+    })();
+  }, [team.id, isAuthenticated, user]);
+
+  if (!meta?.captainCanEdit) {
+    if (user && (team.captainUserId === user.id || team.viceCaptainUserId === user.id || team.courtCaptainUserId === user.id)) {
+      return <p className="text-muted">Team editing is locked for this season or team.</p>;
+    }
+    return null;
+  }
+
+  const save = async () => {
+    setSaving(true);
+    setMessage(null);
+    try {
+      const body: Record<string, unknown> = {
+        hexColor: hexColor.startsWith("#") ? hexColor : `#${hexColor}`,
+        brickColor,
+        logoUrl: logoUrl || null,
+        roster,
+      };
+      if (meta.staffRole === "captain") body.name = name;
+
+      const res = await authFetch(`${BACKEND_URL}/api/teams/${team.id}/staff`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Save failed");
+      setMessage("Saved");
+      onUpdated?.(data);
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="team-staff-edit" style={{ marginTop: "1.5rem", paddingTop: "1rem", borderTop: "1px solid #ddd" }}>
+      <h3>Edit team ({meta.staffRole})</h3>
+      {meta.staffRole === "captain" && (
+        <label>
+          Name
+          <input value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+      )}
+      <label>
+        Hex
+        <input value={hexColor} onChange={(e) => setHexColor(e.target.value)} />
+      </label>
+      <label>
+        Brick
+        <input value={brickColor} onChange={(e) => setBrickColor(e.target.value)} />
+      </label>
+      <label>
+        Logo URL
+        <input value={logoUrl} onChange={(e) => setLogoUrl(e.target.value)} />
+      </label>
+      <h4>Roster</h4>
+      {roster.map((row, i) => (
+        <div key={i} className="roster-row">
+          <input
+            value={row.discord}
+            placeholder="Discord"
+            onChange={(e) =>
+              setRoster((r) => r.map((x, idx) => (idx === i ? { ...x, discord: e.target.value } : x)))
+            }
+          />
+          <input
+            value={row.roblox}
+            placeholder="Roblox"
+            onChange={(e) =>
+              setRoster((r) => r.map((x, idx) => (idx === i ? { ...x, roblox: e.target.value } : x)))
+            }
+          />
+        </div>
+      ))}
+      <button type="button" onClick={() => setRoster((r) => [...r, { discord: "", roblox: "" }])}>
+        Add player
+      </button>
+      <div className="form-actions">
+        <button type="button" disabled={saving} onClick={() => void save()}>
+          {saving ? "Saving…" : "Save changes"}
+        </button>
+      </div>
+      {message && <p>{message}</p>}
+    </section>
+  );
+};
+
+export default TeamStaffEdit;

--- a/FE/src/components/Teams.tsx
+++ b/FE/src/components/Teams.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from "react";
 /* Bring in the navigate helper from React Router */
 import { useNavigate }                          from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useMediumTeams, useSkinnySeasons }                             from "../hooks/allFetch";
 import "../styles/Teams.css";
 import "../styles/ListingPage.css";
+import "../styles/TeamRegistrations.css";
 import SearchBar                                from "./Searchbar";
 import Pagination                               from "./Pagination";
 import FilterBar                                from "./ui/FilterBar";
@@ -101,6 +103,13 @@ const Teams: React.FC = () =>
 
     return (
         <div className={`teams-page ${loading ? 'loading' : ''}`}>
+            <div className="team-regs-nav" style={{ padding: "0.75rem 1rem" }}>
+                <span className="team-regs-nav-active">League teams</span>
+                <span>·</span>
+                <Link to="/teams/registrations">Team registrations</Link>
+                <span>·</span>
+                <Link to="/teams/register">Register a team</Link>
+            </div>
             <div className="listing-controls-toolbar">
                     <FilterBar onReset={(searchQuery || seasonFilter || placementFilter) ? clearFilters : undefined}>
                         <div className="teams-season-filter">

--- a/FE/src/components/portal/PortalLayout.tsx
+++ b/FE/src/components/portal/PortalLayout.tsx
@@ -22,6 +22,7 @@ const PortalLayout: React.FC = () => {
               <li><NavLink to="games">Games</NavLink></li>
               <li><NavLink to="stats">Stats</NavLink></li>
               <li><NavLink to="articles">Articles</NavLink></li>
+              <li><NavLink to="registrations">Registrations</NavLink></li>
               <li><NavLink to="applications">Applications</NavLink></li>
               <li><NavLink to="awards">Awards</NavLink></li>
             </ul>

--- a/FE/src/components/portal/RegistrationsHubPage.tsx
+++ b/FE/src/components/portal/RegistrationsHubPage.tsx
@@ -1,0 +1,220 @@
+import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTeamRegistrations, useRegistrationSummary } from "../../hooks/useTeamRegistrations";
+import { authFetch } from "../../hooks/authFetch";
+import { BACKEND_URL } from "../../constants/api";
+import type { RegionCode, TeamRegistration } from "../../types/interfaces";
+import "../../styles/TeamRegistrations.css";
+
+type Conflict = {
+  type: string;
+  teamName?: string;
+  roblox?: string;
+  existingTeamName?: string;
+  existingTeamId?: number;
+};
+
+const RegistrationsHubPage: React.FC = () => {
+  const [region, setRegion] = useState<RegionCode>("na");
+  const { data, loading, error, reload } = useTeamRegistrations({ region, full: true });
+  const summary = useRegistrationSummary(region);
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const [conflicts, setConflicts] = useState<Conflict[] | null>(null);
+  const [conflictId, setConflictId] = useState<number | null>(null);
+  const [rename, setRename] = useState("");
+  const [playerActions, setPlayerActions] = useState<Record<string, "transfer" | "exclude">>({});
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const header = useMemo(() => {
+    if (!summary) return "Accepted —";
+    if (summary.capacity != null) return `Accepted ${summary.accepted}/${summary.capacity}`;
+    return `Accepted ${summary.accepted}`;
+  }, [summary]);
+
+  const act = async (id: number, path: string, body?: unknown) => {
+    setMsg(null);
+    const res = await authFetch(`${BACKEND_URL}/api/team-registrations/${id}/${path}`, {
+      method: "POST",
+      headers: body ? { "Content-Type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.status === 409 && data.conflicts) {
+      setConflictId(id);
+      setConflicts(data.conflicts);
+      setRename(data.registration?.teamName || "");
+      return;
+    }
+    if (!res.ok) {
+      setMsg(data.error || "Action failed");
+      return;
+    }
+    setConflicts(null);
+    setConflictId(null);
+    setMsg("Updated");
+    await reload();
+  };
+
+  const resolve = async (decision?: "pending" | "denied") => {
+    if (!conflictId) return;
+    if (decision) {
+      await act(conflictId, "resolve", { decision });
+      return;
+    }
+    const players = Object.entries(playerActions).map(([roblox, action]) => ({ roblox, action }));
+    await act(conflictId, "resolve", { teamName: rename || undefined, players });
+  };
+
+  return (
+    <div className="team-regs-page">
+      <h1>Registrations</h1>
+      <p>
+        Manage team applications. Other registration types can be added here later.{" "}
+        <Link to="/portal/teams">League teams CRUD</Link>
+      </p>
+
+      <div className="team-regs-region-tabs">
+        {(["na", "eu", "as"] as RegionCode[]).map((r) => (
+          <button
+            key={r}
+            type="button"
+            className={region === r ? "active" : undefined}
+            onClick={() => {
+              setRegion(r);
+              setExpanded(null);
+            }}
+          >
+            {r.toUpperCase()}
+          </button>
+        ))}
+      </div>
+
+      <h2>Teams · {region.toUpperCase()}</h2>
+      <p>{header}</p>
+      {msg && <p>{msg}</p>}
+      {loading && <p>Loading…</p>}
+      {error && <p className="form-error">{error}</p>}
+
+      <div className="team-regs-table-wrap">
+        <table className="team-regs-table">
+          <thead>
+            <tr>
+              <th>Team</th>
+              <th>Submitter</th>
+              <th>Captain</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((row: TeamRegistration) => (
+              <React.Fragment key={row.id}>
+                <tr
+                  className={`status-${row.status}`}
+                  onClick={() => setExpanded(expanded === row.id ? null : row.id)}
+                >
+                  <td>{row.teamName}</td>
+                  <td>{row.submittedBy?.username || row.submittedByUserId}</td>
+                  <td>
+                    {row.captainDiscord} / {row.captainRoblox}
+                  </td>
+                  <td>{row.status}</td>
+                </tr>
+                {expanded === row.id && (
+                  <tr className={`status-${row.status}`}>
+                    <td colSpan={4}>
+                      <div className="team-regs-detail">
+                        <p>
+                          Hex {row.hexColor} · Brick {row.brickColor}
+                        </p>
+                        <p>
+                          Vice: {row.viceDiscord} / {row.viceRoblox}
+                        </p>
+                        <ul>
+                          {(row.roster || []).map((p, i) => (
+                            <li key={i}>
+                              {p.discord} — {p.roblox}
+                            </li>
+                          ))}
+                        </ul>
+                        <div className="form-actions">
+                          {(row.status === "pending" || row.status === "conflict") && (
+                            <>
+                              <button type="button" onClick={() => void act(row.id, "accept")}>
+                                Accept
+                              </button>
+                              <button type="button" onClick={() => void act(row.id, "deny")}>
+                                Deny
+                              </button>
+                            </>
+                          )}
+                          {row.status === "accepted" && (
+                            <button type="button" onClick={() => void act(row.id, "revoke")}>
+                              Revoke (while apps open)
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {conflicts && conflictId && (
+        <div className="ui-modal-backdrop" style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,.4)", display: "grid", placeItems: "center", zIndex: 50 }}>
+          <div className="ui-modal" style={{ background: "#fff", padding: "1.25rem", maxWidth: 520, width: "90%" }}>
+            <h3>Resolve conflicts</h3>
+            <label>
+              Team name
+              <input value={rename} onChange={(e) => setRename(e.target.value)} />
+            </label>
+            <ul>
+              {conflicts.map((c, i) => (
+                <li key={i}>
+                  {c.type === "name" && <>Name clash: {c.teamName}</>}
+                  {c.type === "player" && (
+                    <>
+                      Player {c.roblox} on {c.existingTeamName}{" "}
+                      <select
+                        value={playerActions[c.roblox!] || ""}
+                        onChange={(e) =>
+                          setPlayerActions((prev) => ({
+                            ...prev,
+                            [c.roblox!]: e.target.value as "transfer" | "exclude",
+                          }))
+                        }
+                      >
+                        <option value="">Choose…</option>
+                        <option value="transfer">Transfer</option>
+                        <option value="exclude">Exclude</option>
+                      </select>
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
+            <div className="form-actions">
+              <button type="button" onClick={() => void resolve()}>
+                Apply &amp; accept
+              </button>
+              <button type="button" onClick={() => void resolve("pending")}>
+                Revert pending
+              </button>
+              <button type="button" onClick={() => void resolve("denied")}>
+                Deny
+              </button>
+              <button type="button" onClick={() => { setConflicts(null); setConflictId(null); }}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RegistrationsHubPage;

--- a/FE/src/components/portal/SeasonsPage.tsx
+++ b/FE/src/components/portal/SeasonsPage.tsx
@@ -310,6 +310,75 @@ const SeasonsPage: React.FC = () =>
             ),
         },
         {
+            key: "registrationsOpen",
+            header: "Apps Open",
+            render: (row: Season) => (
+                <input
+                    type="checkbox"
+                    checked={Boolean(row.registrationsOpen)}
+                    onChange={async (e) => {
+                        try {
+                            const updated = await patchSeason(row.id, {
+                                registrationsOpen: e.target.checked,
+                            });
+                            setLocalSeasons((prev) =>
+                                prev.map((s) => (s.id === row.id ? { ...s, ...updated } : s))
+                            );
+                        } catch (err) {
+                            console.error(err);
+                        }
+                    }}
+                />
+            ),
+        },
+        {
+            key: "captainEditEnabled",
+            header: "Staff Edit",
+            render: (row: Season) => (
+                <input
+                    type="checkbox"
+                    checked={row.captainEditEnabled !== false}
+                    onChange={async (e) => {
+                        try {
+                            const updated = await patchSeason(row.id, {
+                                captainEditEnabled: e.target.checked,
+                            });
+                            setLocalSeasons((prev) =>
+                                prev.map((s) => (s.id === row.id ? { ...s, ...updated } : s))
+                            );
+                        } catch (err) {
+                            console.error(err);
+                        }
+                    }}
+                />
+            ),
+        },
+        {
+            key: "maxTeams",
+            header: "Max Teams",
+            render: (row: Season) => (
+                <input
+                    type="number"
+                    min={1}
+                    style={{ width: "4.5rem" }}
+                    defaultValue={row.maxTeams ?? undefined}
+                    placeholder="—"
+                    onBlur={async (e) => {
+                        const raw = e.target.value.trim();
+                        const maxTeams = raw === "" ? null : Number(raw);
+                        try {
+                            const updated = await patchSeason(row.id, { maxTeams });
+                            setLocalSeasons((prev) =>
+                                prev.map((s) => (s.id === row.id ? { ...s, ...updated } : s))
+                            );
+                        } catch (err) {
+                            console.error(err);
+                        }
+                    }}
+                />
+            ),
+        },
+        {
             key:    "image",
             header: "Image URL",
             render: (row: Season) => (

--- a/FE/src/components/portal/TeamsPage.tsx
+++ b/FE/src/components/portal/TeamsPage.tsx
@@ -19,6 +19,8 @@ import RegionSeasonFields from "../ui/RegionSeasonFields";
 import { useFormRegionSeason } from "../../hooks/useFormRegionSeason";
 import { TEAM_PLACEMENT_OPTIONS } from "../../constants/teamPlacements";
 import { useDebouncedValue } from "../../hooks/useDebouncedValue";
+import { authFetch } from "../../hooks/authFetch";
+import { BACKEND_URL } from "../../constants/api";
 
 type EditField =
   | "name"
@@ -327,6 +329,32 @@ const TeamsPage: React.FC = () => {
             t.logoUrl || "N/A"
           )}
         </div>
+      ),
+    },
+    {
+      key: "captainEditEnabled",
+      header: "Staff Edit",
+      render: (t) => (
+        <input
+          type="checkbox"
+          checked={t.captainEditEnabled !== false}
+          onChange={async (e) => {
+            try {
+              const res = await authFetch(`${BACKEND_URL}/api/teams/${t.id}/flags`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ captainEditEnabled: e.target.checked }),
+              });
+              if (!res.ok) throw new Error("Failed");
+              const updated = await res.json();
+              setLocalTeams((prev) =>
+                prev.map((x) => (x.id === t.id ? { ...x, ...updated } : x))
+              );
+            } catch (err) {
+              console.error(err);
+            }
+          }}
+        />
       ),
     },
     {

--- a/FE/src/styles/TeamRegistrations.css
+++ b/FE/src/styles/TeamRegistrations.css
@@ -1,0 +1,152 @@
+.team-regs-page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+}
+
+.team-regs-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.team-regs-nav a {
+  color: var(--color-accent, #4a90c8);
+}
+
+.team-regs-nav-active {
+  font-weight: 600;
+}
+
+.team-regs-header h1 {
+  margin: 0 0 0.35rem;
+}
+
+.team-regs-spots {
+  color: var(--color-text-muted, #5a6a7a);
+}
+
+.team-regs-region-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin: 1.25rem 0;
+}
+
+.team-regs-region-tabs button {
+  border: 1px solid #c5d0dc;
+  background: #fff;
+  padding: 0.45rem 0.9rem;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.team-regs-region-tabs button.active {
+  background: #2d3c50;
+  color: #fff;
+  border-color: #2d3c50;
+}
+
+.team-regs-table-wrap {
+  overflow-x: auto;
+}
+
+.team-regs-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.team-regs-table th,
+.team-regs-table td {
+  text-align: left;
+  padding: 0.75rem 0.85rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.team-regs-table tbody tr {
+  cursor: pointer;
+  background: #fff;
+}
+
+.team-regs-table tbody tr.status-accepted {
+  background: #d8f3dc;
+}
+
+.team-regs-table tbody tr.status-denied {
+  background: #f8d7da;
+}
+
+.team-regs-table tbody tr.status-pending,
+.team-regs-table tbody tr.status-conflict {
+  background: #fff;
+}
+
+.team-regs-table tbody tr.selected {
+  outline: 2px solid #2d3c50;
+}
+
+.team-regs-detail {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.team-regs-error {
+  color: #b00020;
+}
+
+.team-reg-form {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+}
+
+.team-reg-form fieldset {
+  border: 1px solid #d0d7de;
+  margin: 0 0 1.25rem;
+  padding: 1rem;
+}
+
+.team-reg-form legend {
+  font-weight: 600;
+  padding: 0 0.35rem;
+}
+
+.team-reg-form label {
+  display: block;
+  margin-bottom: 0.75rem;
+}
+
+.team-reg-form input[type="text"],
+.team-reg-form input[type="url"],
+.team-reg-form textarea,
+.team-reg-form select {
+  display: block;
+  width: 100%;
+  margin-top: 0.25rem;
+  padding: 0.45rem 0.55rem;
+}
+
+.roster-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.form-error {
+  color: #b00020;
+  margin-bottom: 1rem;
+}
+
+.form-success {
+  color: #1b7a3d;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- Public register/list/detail pages under `/teams/registrations` and `/teams/register`
- Admin Registrations hub with conflict modal; season/team portal toggles
- Captain staff edit panel on single-team pages

## Test plan
- [ ] Browse public registrations by region; open row detail
- [ ] Submit a team application while logged in
- [ ] Admin accept/deny/revoke and conflict resolve from `/portal/registrations`
- [ ] Toggle season apps-open / staff-edit / max teams; per-team staff-edit lock
- [ ] Captain can edit when both flags allow

**Base:** `feat/team-registrations-api` (merge stack in order)