### PR TITLE
Team application portal + local Docker/UI polish

### DIFF
--- a/BE/.env.example
+++ b/BE/.env.example
@@ -115,3 +115,12 @@ VITE_BACKEND_URL=http://localhost:3000
 
 # Optional — required for Challonge tournament import in the admin portal
 # CHALLONGE_API_KEY=your-challonge-api-key
+
+# Roblox OAuth (https://create.roblox.com → OAuth 2.0)
+# Register this redirect URI on the Roblox OAuth app:
+#   http://localhost:3000/api/auth/roblox/callback
+ROBLOX_OAUTH_CLIENT_ID=
+ROBLOX_OAUTH_CLIENT_SECRET=
+ROBLOX_OAUTH_REDIRECT_URI=http://localhost:3000/api/auth/roblox/callback
+FRONTEND_URL=http://localhost:5173
+BACKEND_PUBLIC_URL=http://localhost:3000

--- a/BE/src/middleware/rateLimit.ts
+++ b/BE/src/middleware/rateLimit.ts
@@ -1,4 +1,4 @@
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 
 export const loginRateLimiter = rateLimit({
     windowMs: 60 * 1000,
@@ -24,7 +24,7 @@ export const adminRateLimiter = rateLimit({
         if (user?.id) {
             return `admin-user-${user.id}`;
         }
-        return req.ip ?? "unknown";
+        return ipKeyGenerator(req.ip ?? "unknown");
     },
     message: { error: "Too many admin requests. Please try again later." },
     standardHeaders: true,

--- a/BE/src/modules/index.ts
+++ b/BE/src/modules/index.ts
@@ -12,6 +12,7 @@ import { registerRecordRoutes } from './records/records.routes.js';
 import { registerTriviaRoutes } from './trivia/trivia.routes.js';
 import { registerApplicationRoutes } from './applications/application.routes.js';
 import { registerRegionRoutes } from './regions/region.routes.js';
+import { registerTeamRegistrationRoutes } from './team-registrations/team-registration.routes.js';
 import { cacheHealthCheck } from '../middleware/cache.js';
 import { authenticateToken } from '../middleware/authentication.js';
 import { authorizeRoles } from '../middleware/authorizeRoles.js';
@@ -35,6 +36,7 @@ export function registerModules(app: Application): void
     registerRecordRoutes(app);
     registerTriviaRoutes(app);
     registerApplicationRoutes(app);
+    registerTeamRegistrationRoutes(app);
 
     // Cache health check route (admin only)
     app.get('/api/cache/health', authenticateToken, authorizeRoles("admin", "superadmin"), cacheHealthCheck);

--- a/BE/src/modules/roblox/roblox-auth.controller.ts
+++ b/BE/src/modules/roblox/roblox-auth.controller.ts
@@ -1,0 +1,236 @@
+import crypto from "crypto";
+import { Request, Response, NextFunction } from "express";
+import { UserService } from "../user/user.service.js";
+import { setAuthCookies } from "../../middleware/authCookie.js";
+import { ConflictError } from "../../errors/ConflictError.js";
+import { UnauthorizedError } from "../../errors/UnauthorizedError.js";
+import { getJwtSecret } from "../../middleware/authValidation.js";
+
+export type RobloxOAuthIntent = "connect" | "signup" | "login";
+
+const AUTHORIZE_URL = "https://apis.roblox.com/oauth/v1/authorize";
+const TOKEN_URL = "https://apis.roblox.com/oauth/v1/token";
+const USERINFO_URL = "https://apis.roblox.com/oauth/v1/userinfo";
+const STATE_COOKIE = "roblox_oauth_state";
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+interface OAuthStatePayload {
+    intent: RobloxOAuthIntent;
+    userId?: number;
+    nonce: string;
+    exp: number;
+}
+
+function getFrontendUrl(): string {
+    return process.env.FRONTEND_URL || process.env.CORS_ORIGINS?.split(",")[0]?.trim() || "http://localhost:5173";
+}
+
+function getRobloxConfig(): { clientId: string; clientSecret: string; redirectUri: string } {
+    const clientId = process.env.ROBLOX_OAUTH_CLIENT_ID;
+    const clientSecret = process.env.ROBLOX_OAUTH_CLIENT_SECRET;
+    const redirectUri =
+        process.env.ROBLOX_OAUTH_REDIRECT_URI ||
+        `${process.env.BACKEND_PUBLIC_URL || "http://localhost:3000"}/api/auth/roblox/callback`;
+
+    if (!clientId || !clientSecret) {
+        throw new Error("Roblox OAuth is not configured (ROBLOX_OAUTH_CLIENT_ID / ROBLOX_OAUTH_CLIENT_SECRET)");
+    }
+
+    return { clientId, clientSecret, redirectUri };
+}
+
+function signState(payload: OAuthStatePayload): string {
+    const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const sig = crypto.createHmac("sha256", getJwtSecret()).update(body).digest("base64url");
+    return `${body}.${sig}`;
+}
+
+function verifyState(state: string): OAuthStatePayload {
+    const [body, sig] = state.split(".");
+    if (!body || !sig) throw new UnauthorizedError("Invalid OAuth state");
+    const expected = crypto.createHmac("sha256", getJwtSecret()).update(body).digest("base64url");
+    if (sig.length !== expected.length || !crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+        throw new UnauthorizedError("Invalid OAuth state signature");
+    }
+    const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8")) as OAuthStatePayload;
+    if (payload.exp < Date.now()) throw new UnauthorizedError("OAuth state expired");
+    return payload;
+}
+
+export class RobloxAuthController {
+    private userService = new UserService();
+
+    start = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const intent = (req.query.intent as RobloxOAuthIntent) || "login";
+            if (!["connect", "signup", "login"].includes(intent)) {
+                res.status(400).json({ error: "intent must be connect, signup, or login" });
+                return;
+            }
+
+            if (intent === "connect" && !req.user?.id) {
+                res.status(401).json({ error: "Must be logged in to connect Roblox" });
+                return;
+            }
+
+            const { clientId, redirectUri } = getRobloxConfig();
+            const payload: OAuthStatePayload = {
+                intent,
+                userId: intent === "connect" ? req.user!.id : undefined,
+                nonce: crypto.randomBytes(16).toString("hex"),
+                exp: Date.now() + STATE_TTL_MS,
+            };
+            const state = signState(payload);
+
+            res.cookie(STATE_COOKIE, state, {
+                httpOnly: true,
+                sameSite: "lax",
+                secure: process.env.NODE_ENV === "production",
+                maxAge: STATE_TTL_MS,
+                path: "/",
+            });
+
+            const url = new URL(AUTHORIZE_URL);
+            url.searchParams.set("client_id", clientId);
+            url.searchParams.set("redirect_uri", redirectUri);
+            url.searchParams.set("scope", "openid profile");
+            url.searchParams.set("response_type", "code");
+            url.searchParams.set("state", state);
+
+            res.json({ url: url.toString() });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    callback = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        const frontend = getFrontendUrl();
+        try {
+            const code = typeof req.query.code === "string" ? req.query.code : null;
+            const state = typeof req.query.state === "string" ? req.query.state : req.cookies?.[STATE_COOKIE];
+            const oauthError = typeof req.query.error === "string" ? req.query.error : null;
+
+            if (oauthError) {
+                res.redirect(`${frontend}/login?roblox=error&message=${encodeURIComponent(oauthError)}`);
+                return;
+            }
+            if (!code || !state) {
+                res.redirect(`${frontend}/login?roblox=error&message=${encodeURIComponent("Missing code or state")}`);
+                return;
+            }
+
+            const payload = verifyState(state);
+            const { clientId, clientSecret, redirectUri } = getRobloxConfig();
+
+            const tokenRes = await fetch(TOKEN_URL, {
+                method: "POST",
+                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                body: new URLSearchParams({
+                    grant_type: "authorization_code",
+                    code,
+                    client_id: clientId,
+                    client_secret: clientSecret,
+                    redirect_uri: redirectUri,
+                }),
+            });
+
+            if (!tokenRes.ok) {
+                const text = await tokenRes.text();
+                console.error("Roblox token exchange failed", text);
+                res.redirect(`${frontend}/login?roblox=error&message=${encodeURIComponent("Token exchange failed")}`);
+                return;
+            }
+
+            const tokenJson = (await tokenRes.json()) as { access_token: string };
+            const infoRes = await fetch(USERINFO_URL, {
+                headers: { Authorization: `Bearer ${tokenJson.access_token}` },
+            });
+            if (!infoRes.ok) {
+                res.redirect(`${frontend}/login?roblox=error&message=${encodeURIComponent("Failed to fetch Roblox profile")}`);
+                return;
+            }
+
+            const info = (await infoRes.json()) as {
+                sub?: string;
+                preferred_username?: string;
+                nickname?: string;
+                name?: string;
+            };
+
+            const robloxUserId = String(info.sub || "");
+            const robloxUsername = info.preferred_username || info.nickname || info.name || "";
+            if (!robloxUserId || !robloxUsername) {
+                res.redirect(`${frontend}/login?roblox=error&message=${encodeURIComponent("Incomplete Roblox profile")}`);
+                return;
+            }
+
+            res.clearCookie(STATE_COOKIE, { path: "/" });
+
+            if (payload.intent === "connect") {
+                if (!payload.userId) {
+                    res.redirect(`${frontend}/profile?roblox=error&message=${encodeURIComponent("Not logged in")}`);
+                    return;
+                }
+                await this.userService.connectRoblox(payload.userId, robloxUserId, robloxUsername);
+                const { user, token } = await this.userService.issueTokenForUser(payload.userId);
+                setAuthCookies(res, token);
+                res.redirect(`${frontend}/profile?roblox=connected&user=${encodeURIComponent(user.robloxUsername || robloxUsername)}`);
+                return;
+            }
+
+            if (payload.intent === "login") {
+                const existing = await this.userService.findByRobloxUserId(robloxUserId);
+                if (!existing) {
+                    res.redirect(`${frontend}/signup?roblox=need_signup`);
+                    return;
+                }
+                const { token } = await this.userService.issueTokenForUser(existing.id);
+                setAuthCookies(res, token);
+                res.redirect(`${frontend}/?roblox=login`);
+                return;
+            }
+
+            // signup
+            const existing = await this.userService.findByRobloxUserId(robloxUserId);
+            if (existing) {
+                const { token } = await this.userService.issueTokenForUser(existing.id);
+                setAuthCookies(res, token);
+                res.redirect(`${frontend}/?roblox=login`);
+                return;
+            }
+
+            const { token } = await this.userService.createUserFromRoblox(robloxUserId, robloxUsername);
+            setAuthCookies(res, token);
+            res.redirect(`${frontend}/?roblox=signup`);
+        } catch (error) {
+            if (error instanceof ConflictError) {
+                res.redirect(`${frontend}/profile?roblox=error&message=${encodeURIComponent(error.message)}`);
+                return;
+            }
+            next(error);
+        }
+    };
+
+    unlink = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const user = await this.userService.unlinkRoblox(req.user.id);
+            res.json(this.userService.toPublicUser(user));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    adminUnlink = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const targetId = Number(req.params.id);
+            const user = await this.userService.unlinkRoblox(targetId);
+            res.json(this.userService.toPublicUser(user));
+        } catch (error) {
+            next(error);
+        }
+    };
+}

--- a/BE/src/modules/roblox/roblox-auth.controller.ts
+++ b/BE/src/modules/roblox/roblox-auth.controller.ts
@@ -25,15 +25,15 @@ function getFrontendUrl(): string {
     return process.env.FRONTEND_URL || process.env.CORS_ORIGINS?.split(",")[0]?.trim() || "http://localhost:5173";
 }
 
-function getRobloxConfig(): { clientId: string; clientSecret: string; redirectUri: string } {
-    const clientId = process.env.ROBLOX_OAUTH_CLIENT_ID;
-    const clientSecret = process.env.ROBLOX_OAUTH_CLIENT_SECRET;
+function getRobloxConfig(): { clientId: string; clientSecret: string; redirectUri: string } | null {
+    const clientId = process.env.ROBLOX_OAUTH_CLIENT_ID?.trim();
+    const clientSecret = process.env.ROBLOX_OAUTH_CLIENT_SECRET?.trim();
     const redirectUri =
-        process.env.ROBLOX_OAUTH_REDIRECT_URI ||
+        process.env.ROBLOX_OAUTH_REDIRECT_URI?.trim() ||
         `${process.env.BACKEND_PUBLIC_URL || "http://localhost:3000"}/api/auth/roblox/callback`;
 
     if (!clientId || !clientSecret) {
-        throw new Error("Roblox OAuth is not configured (ROBLOX_OAUTH_CLIENT_ID / ROBLOX_OAUTH_CLIENT_SECRET)");
+        return null;
     }
 
     return { clientId, clientSecret, redirectUri };
@@ -73,7 +73,15 @@ export class RobloxAuthController {
                 return;
             }
 
-            const { clientId, redirectUri } = getRobloxConfig();
+            const config = getRobloxConfig();
+            if (!config) {
+                res.status(503).json({
+                    error:
+                        "Roblox OAuth is not configured. Set ROBLOX_OAUTH_CLIENT_ID and ROBLOX_OAUTH_CLIENT_SECRET (and register redirect URI http://localhost:3000/api/auth/roblox/callback).",
+                });
+                return;
+            }
+            const { clientId, redirectUri } = config;
             const payload: OAuthStatePayload = {
                 intent,
                 userId: intent === "connect" ? req.user!.id : undefined,
@@ -120,7 +128,14 @@ export class RobloxAuthController {
             }
 
             const payload = verifyState(state);
-            const { clientId, clientSecret, redirectUri } = getRobloxConfig();
+            const config = getRobloxConfig();
+            if (!config) {
+                res.redirect(
+                    `${frontend}/login?roblox=error&message=${encodeURIComponent("Roblox OAuth is not configured")}`
+                );
+                return;
+            }
+            const { clientId, clientSecret, redirectUri } = config;
 
             const tokenRes = await fetch(TOKEN_URL, {
                 method: "POST",

--- a/BE/src/modules/roblox/roblox.routes.ts
+++ b/BE/src/modules/roblox/roblox.routes.ts
@@ -1,13 +1,39 @@
 import { Application, Router } from 'express';
 import { RobloxController } from './roblox.controller.js';
+import { RobloxAuthController } from './roblox-auth.controller.js';
 import { robloxRateLimiter } from '../../middleware/rateLimit.js';
+import { authenticateToken } from '../../middleware/authentication.js';
+import { authorizeRoles } from '../../middleware/authorizeRoles.js';
 
 export function registerRobloxRoutes(app: Application): void
 {
     const router = Router();
     const robloxController = new RobloxController();
+    const authController = new RobloxAuthController();
 
     router.get('/avatar/:username', robloxRateLimiter, robloxController.getAvatarByUsername);
 
     app.use('/api/roblox', router);
+
+    const authRouter = Router();
+    authRouter.get('/roblox/start', (req, res, next) => {
+        // connect requires auth; login/signup do not
+        if (req.query.intent === 'connect') {
+            return authenticateToken(req, res, (err?: unknown) => {
+                if (err) return next(err);
+                return authController.start(req, res, next);
+            });
+        }
+        return authController.start(req, res, next);
+    });
+    authRouter.get('/roblox/callback', authController.callback);
+    authRouter.post('/roblox/unlink', authenticateToken, authController.unlink);
+    authRouter.post(
+        '/roblox/unlink/:id',
+        authenticateToken,
+        authorizeRoles('admin', 'superadmin'),
+        authController.adminUnlink
+    );
+
+    app.use('/api/auth', authRouter);
 }

--- a/BE/src/modules/seasons/season.controller.ts
+++ b/BE/src/modules/seasons/season.controller.ts
@@ -119,7 +119,10 @@ export class SeasonController
                 startDate,
                 endDate,
                 theme,
-                image
+                image,
+                registrationsOpen,
+                captainEditEnabled,
+                maxTeams,
             } = req.body;
 
             const updated = await this.seasonService.updateSeason(
@@ -128,7 +131,10 @@ export class SeasonController
                 startDate ? new Date(startDate) : undefined,
                 endDate   ? new Date(endDate)   : undefined,
                 theme,
-                image
+                image,
+                registrationsOpen,
+                captainEditEnabled,
+                maxTeams
             );
 
             res.status(200).json(updated);

--- a/BE/src/modules/seasons/season.schema.ts
+++ b/BE/src/modules/seasons/season.schema.ts
@@ -14,4 +14,8 @@ export const createSeasonSchema = z.object({
     region: z.enum(REGION_CODES).optional(),
 });
 
-export const updateSeasonSchema = createSeasonSchema.partial();
+export const updateSeasonSchema = createSeasonSchema.partial().extend({
+    registrationsOpen: z.boolean().optional(),
+    captainEditEnabled: z.boolean().optional(),
+    maxTeams: z.number().int().positive().nullable().optional(),
+});

--- a/BE/src/modules/seasons/season.service.ts
+++ b/BE/src/modules/seasons/season.service.ts
@@ -184,7 +184,10 @@ export class SeasonService
         startDate?: Date,
         endDate?: Date,
         theme?: string,
-        image?: string
+        image?: string,
+        registrationsOpen?: boolean,
+        captainEditEnabled?: boolean,
+        maxTeams?: number | null
     ): Promise<Seasons>
     {
         if (!id) throw new MissingFieldError("Season ID");
@@ -227,6 +230,18 @@ export class SeasonService
         if (image !== undefined)
         {
             season.image = image;
+        }
+
+        if (registrationsOpen !== undefined) {
+            season.registrationsOpen = registrationsOpen;
+        }
+
+        if (captainEditEnabled !== undefined) {
+            season.captainEditEnabled = captainEditEnabled;
+        }
+
+        if (maxTeams !== undefined) {
+            season.maxTeams = maxTeams;
         }
 
         if (season.startDate && season.endDate && season.startDate > season.endDate)

--- a/BE/src/modules/stats/stat.schema.ts
+++ b/BE/src/modules/stats/stat.schema.ts
@@ -31,6 +31,6 @@ export const createStatByNameSchema = createStatSchema
   });
 
 export type CreateStatDto = z.infer<typeof createStatSchema>;
-export type UpdateStatDto = z.infer<typeof createStatSchema.partial()>;
+export type UpdateStatDto = z.infer<typeof updateStatSchema>;
 export type CreateStatByNameDto = z.infer<typeof createStatByNameSchema>;
 

--- a/BE/src/modules/team-registrations/team-registration.controller.ts
+++ b/BE/src/modules/team-registrations/team-registration.controller.ts
@@ -1,0 +1,161 @@
+import { Request, Response, NextFunction } from "express";
+import { TeamRegistrationService } from "./team-registration.service.js";
+import { RegionCode } from "../regions/region.entity.js";
+
+export class TeamRegistrationController {
+    private service = new TeamRegistrationService();
+
+    submit = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const row = await this.service.submit(req.user.id, req.body);
+            res.status(201).json(this.service.toDetailDto(row, true));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    update = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const id = Number(req.params.id);
+            const row = await this.service.updatePending(req.user.id, id, req.body);
+            res.json(this.service.toDetailDto(row, true));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    withdraw = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            await this.service.withdraw(req.user.id, Number(req.params.id));
+            res.status(204).send();
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    list = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const region = typeof req.query.region === "string" ? (req.query.region as RegionCode) : undefined;
+            const seasonId = req.query.seasonId ? Number(req.query.seasonId) : undefined;
+            const status = typeof req.query.status === "string" ? req.query.status : undefined;
+            const rows = await this.service.list({ region, seasonId, status });
+
+            const isAdmin = req.user?.role === "admin" || req.user?.role === "superadmin";
+            if (isAdmin && req.query.full === "1") {
+                res.json(rows.map((r) => this.service.toDetailDto(r, true)));
+                return;
+            }
+            res.json(rows.map((r) => this.service.toPublicDto(r)));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    summary = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const region = typeof req.query.region === "string" ? (req.query.region as RegionCode) : undefined;
+            const seasonId = req.query.seasonId ? Number(req.query.seasonId) : undefined;
+            res.json(await this.service.summary(region, seasonId));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    getOne = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const id = Number(req.params.id);
+            const row = await this.service.getById(id);
+            const isAdmin = req.user?.role === "admin" || req.user?.role === "superadmin";
+            const isOwner = req.user?.id === row.submittedByUserId;
+            if (!isAdmin && !isOwner) {
+                res.json(this.service.toDetailDto(row, false));
+                return;
+            }
+            res.json(this.service.toDetailDto(row, isAdmin));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    accept = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const result = await this.service.tryAccept(Number(req.params.id), req.user.id);
+            if (!result.ok) {
+                res.status(409).json({
+                    error: "Conflicts detected",
+                    conflicts: result.conflicts,
+                    registration: this.service.toDetailDto(result.registration, true),
+                });
+                return;
+            }
+            res.json({
+                registration: this.service.toDetailDto(result.registration, true),
+                team: result.team,
+            });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    resolve = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const result = await this.service.resolve(Number(req.params.id), req.user.id, req.body);
+            if ("ok" in result && result.ok === false) {
+                res.status(409).json({
+                    error: "Conflicts detected",
+                    conflicts: result.conflicts,
+                    registration: this.service.toDetailDto(result.registration, true),
+                });
+                return;
+            }
+            if ("ok" in result && result.ok === true) {
+                res.json({
+                    registration: this.service.toDetailDto(result.registration, true),
+                    team: result.team,
+                });
+                return;
+            }
+            res.json({ registration: this.service.toDetailDto((result as { registration: never }).registration, true) });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    deny = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const row = await this.service.deny(Number(req.params.id));
+            res.json(this.service.toDetailDto(row, true));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    revoke = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const row = await this.service.revoke(Number(req.params.id));
+            res.json(this.service.toDetailDto(row, true));
+        } catch (error) {
+            next(error);
+        }
+    };
+}

--- a/BE/src/modules/team-registrations/team-registration.routes.ts
+++ b/BE/src/modules/team-registrations/team-registration.routes.ts
@@ -1,0 +1,69 @@
+import { Application, Router } from "express";
+import { validate } from "../../middleware/validate.js";
+import { authenticateToken } from "../../middleware/authentication.js";
+import { authorizeRoles } from "../../middleware/authorizeRoles.js";
+import { TeamRegistrationController } from "./team-registration.controller.js";
+import {
+    createTeamRegistrationSchema,
+    updateTeamRegistrationSchema,
+    resolveRegistrationSchema,
+} from "./team-registration.schema.js";
+
+/** Optional auth — attaches user if token present, never 401s. */
+function optionalAuth(req: any, res: any, next: any): void {
+    const header = req.header?.("Authorization") || "";
+    const hasCookie = Boolean(req.cookies?.auth_token);
+    if (!header && !hasCookie) {
+        next();
+        return;
+    }
+    authenticateToken(req, res, (err?: unknown) => {
+        if (err) {
+            // ignore invalid token for public list enrichment
+            next();
+            return;
+        }
+        next();
+    });
+}
+
+export function registerTeamRegistrationRoutes(app: Application): void {
+    const router = Router();
+    const controller = new TeamRegistrationController();
+
+    router.get("/", optionalAuth, controller.list);
+    router.get("/summary", controller.summary);
+    router.get("/:id", optionalAuth, controller.getOne);
+
+    router.post("/", authenticateToken, validate(createTeamRegistrationSchema), controller.submit);
+    router.patch("/:id", authenticateToken, validate(updateTeamRegistrationSchema), controller.update);
+    router.delete("/:id", authenticateToken, controller.withdraw);
+
+    router.post(
+        "/:id/accept",
+        authenticateToken,
+        authorizeRoles("admin", "superadmin"),
+        controller.accept
+    );
+    router.post(
+        "/:id/resolve",
+        authenticateToken,
+        authorizeRoles("admin", "superadmin"),
+        validate(resolveRegistrationSchema),
+        controller.resolve
+    );
+    router.post(
+        "/:id/deny",
+        authenticateToken,
+        authorizeRoles("admin", "superadmin"),
+        controller.deny
+    );
+    router.post(
+        "/:id/revoke",
+        authenticateToken,
+        authorizeRoles("admin", "superadmin"),
+        controller.revoke
+    );
+
+    app.use("/api/team-registrations", router);
+}

--- a/BE/src/modules/team-registrations/team-registration.schema.ts
+++ b/BE/src/modules/team-registrations/team-registration.schema.ts
@@ -6,41 +6,63 @@ const rosterEntrySchema = z.object({
     roblox: z.string().min(1),
 });
 
-export const createTeamRegistrationSchema = z
-    .object({
-        region: z.enum(REGION_CODES),
-        teamName: z.string().min(1).max(64),
-        hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/, { message: "hexColor must be #RRGGBB" }),
-        brickColor: z.string().min(1).max(64),
-        captainDiscord: z.string().min(1),
-        captainRoblox: z.string().min(1),
-        viceDiscord: z.string().min(1),
-        viceRoblox: z.string().min(1),
-        roster: z.array(rosterEntrySchema).min(10),
-        agreeCivilScheduling: z.literal(true),
-        confidentWillParticipate: z.literal(true),
-        priorLeagueExperience: z.string().max(2000).optional().nullable(),
-        logoJerseyAck: z.literal(true),
-    })
+const teamRegistrationFields = z.object({
+    region: z.enum(REGION_CODES),
+    teamName: z.string().min(1).max(64),
+    hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/, { message: "hexColor must be #RRGGBB" }),
+    brickColor: z.string().min(1).max(64),
+    captainDiscord: z.string().min(1),
+    captainRoblox: z.string().min(1),
+    viceDiscord: z.string().min(1),
+    viceRoblox: z.string().min(1),
+    roster: z.array(rosterEntrySchema).min(10),
+    agreeCivilScheduling: z.literal(true),
+    confidentWillParticipate: z.literal(true),
+    priorLeagueExperience: z.string().max(2000).optional().nullable(),
+    logoJerseyAck: z.literal(true),
+});
+
+function refineTeamRegistrationRoster(
+    data: {
+        roster: Array<{ roblox: string }>;
+        captainRoblox: string;
+        viceRoblox: string;
+    },
+    ctx: z.RefinementCtx
+): void {
+    const robloxes = data.roster.map((r) => r.roblox.trim().toLowerCase());
+    const unique = new Set(robloxes);
+    if (unique.size !== robloxes.length) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Duplicate Roblox usernames in roster", path: ["roster"] });
+    }
+    const captain = data.captainRoblox.trim().toLowerCase();
+    const vice = data.viceRoblox.trim().toLowerCase();
+    if (!robloxes.includes(captain)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include captain Roblox", path: ["roster"] });
+    }
+    if (!robloxes.includes(vice)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include vice Roblox", path: ["roster"] });
+    }
+}
+
+export const createTeamRegistrationSchema = teamRegistrationFields.superRefine(refineTeamRegistrationRoster);
+
+export const updateTeamRegistrationSchema = teamRegistrationFields
+    .partial()
+    .omit({ region: true })
     .superRefine((data, ctx) => {
-        const robloxes = data.roster.map((r) => r.roblox.trim().toLowerCase());
-        const unique = new Set(robloxes);
-        if (unique.size !== robloxes.length) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Duplicate Roblox usernames in roster", path: ["roster"] });
-        }
-        const captain = data.captainRoblox.trim().toLowerCase();
-        const vice = data.viceRoblox.trim().toLowerCase();
-        if (!robloxes.includes(captain)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include captain Roblox", path: ["roster"] });
-        }
-        if (!robloxes.includes(vice)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include vice Roblox", path: ["roster"] });
-        }
+        // Only enforce roster inclusion rules when enough fields are present to check.
+        if (!data.roster || !data.captainRoblox || !data.viceRoblox) return;
+        refineTeamRegistrationRoster(
+            {
+                roster: data.roster,
+                captainRoblox: data.captainRoblox,
+                viceRoblox: data.viceRoblox,
+            },
+            ctx
+        );
     });
 
-export const updateTeamRegistrationSchema = createTeamRegistrationSchema.partial().omit({
-    region: true,
-});
 
 export const resolveRegistrationSchema = z.object({
     decision: z.enum(["pending", "denied"]).optional(),

--- a/BE/src/modules/team-registrations/team-registration.schema.ts
+++ b/BE/src/modules/team-registrations/team-registration.schema.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { REGION_CODES } from "../regions/region.entity.js";
+
+const rosterEntrySchema = z.object({
+    discord: z.string().min(1),
+    roblox: z.string().min(1),
+});
+
+export const createTeamRegistrationSchema = z
+    .object({
+        region: z.enum(REGION_CODES),
+        teamName: z.string().min(1).max(64),
+        hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/, { message: "hexColor must be #RRGGBB" }),
+        brickColor: z.string().min(1).max(64),
+        captainDiscord: z.string().min(1),
+        captainRoblox: z.string().min(1),
+        viceDiscord: z.string().min(1),
+        viceRoblox: z.string().min(1),
+        roster: z.array(rosterEntrySchema).min(10),
+        agreeCivilScheduling: z.literal(true),
+        confidentWillParticipate: z.literal(true),
+        priorLeagueExperience: z.string().max(2000).optional().nullable(),
+        logoJerseyAck: z.literal(true),
+    })
+    .superRefine((data, ctx) => {
+        const robloxes = data.roster.map((r) => r.roblox.trim().toLowerCase());
+        const unique = new Set(robloxes);
+        if (unique.size !== robloxes.length) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Duplicate Roblox usernames in roster", path: ["roster"] });
+        }
+        const captain = data.captainRoblox.trim().toLowerCase();
+        const vice = data.viceRoblox.trim().toLowerCase();
+        if (!robloxes.includes(captain)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include captain Roblox", path: ["roster"] });
+        }
+        if (!robloxes.includes(vice)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Roster must include vice Roblox", path: ["roster"] });
+        }
+    });
+
+export const updateTeamRegistrationSchema = createTeamRegistrationSchema.partial().omit({
+    region: true,
+});
+
+export const resolveRegistrationSchema = z.object({
+    decision: z.enum(["pending", "denied"]).optional(),
+    teamName: z.string().min(1).max(64).optional(),
+    players: z
+        .array(
+            z.object({
+                roblox: z.string().min(1),
+                action: z.enum(["transfer", "exclude"]),
+            })
+        )
+        .optional(),
+});
+
+export type CreateTeamRegistrationDto = z.infer<typeof createTeamRegistrationSchema>;
+export type UpdateTeamRegistrationDto = z.infer<typeof updateTeamRegistrationSchema>;
+export type ResolveRegistrationDto = z.infer<typeof resolveRegistrationSchema>;
+
+export const staffTeamUpdateSchema = z.object({
+    name: z.string().min(1).max(64).optional(),
+    hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/).optional().nullable(),
+    brickColor: z.string().min(1).max(64).optional().nullable(),
+    logoUrl: z.string().url().optional().nullable(),
+    roster: z.array(rosterEntrySchema).min(10).optional(),
+    captainUserId: z.number().int().positive().optional().nullable(),
+    viceCaptainUserId: z.number().int().positive().optional().nullable(),
+    courtCaptainUserId: z.number().int().positive().optional().nullable(),
+});
+
+export const adminTeamFlagsSchema = z.object({
+    captainEditEnabled: z.boolean().optional(),
+    hexColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/).optional().nullable(),
+    brickColor: z.string().min(1).max(64).optional().nullable(),
+    captainUserId: z.number().int().positive().optional().nullable(),
+    viceCaptainUserId: z.number().int().positive().optional().nullable(),
+    courtCaptainUserId: z.number().int().positive().optional().nullable(),
+});

--- a/BE/src/modules/team-registrations/team-registration.service.ts
+++ b/BE/src/modules/team-registrations/team-registration.service.ts
@@ -1,0 +1,505 @@
+import { Repository } from "typeorm";
+import { AppDataSource } from "../../db/data-source.js";
+import { TeamRegistration, RosterEntry } from "./team-registration.entity.js";
+import { Seasons } from "../seasons/season.entity.js";
+import { Teams } from "../teams/team.entity.js";
+import { Players } from "../players/player.entity.js";
+import { User } from "../user/user.entity.js";
+import { RegionService } from "../regions/region.service.js";
+import { RegionCode } from "../regions/region.entity.js";
+import { UserService } from "../user/user.service.js";
+import { normalizeRobloxUsername } from "../../middleware/authValidation.js";
+import { NotFoundError } from "../../errors/NotFoundError.js";
+import { ConflictError } from "../../errors/ConflictError.js";
+import { UnauthorizedError } from "../../errors/UnauthorizedError.js";
+import type {
+    CreateTeamRegistrationDto,
+    UpdateTeamRegistrationDto,
+    ResolveRegistrationDto,
+} from "./team-registration.schema.js";
+
+export interface NameConflict {
+    type: "name";
+    teamName: string;
+    existingTeamId: number;
+}
+
+export interface PlayerConflict {
+    type: "player";
+    roblox: string;
+    existingTeamId: number;
+    existingTeamName: string;
+    playerId: number;
+}
+
+export type RegistrationConflict = NameConflict | PlayerConflict;
+
+function normalizeRoster(roster: RosterEntry[]): RosterEntry[] {
+    return roster.map((r) => ({
+        discord: r.discord.trim(),
+        roblox: normalizeRobloxUsername(r.roblox),
+    }));
+}
+
+export class TeamRegistrationService {
+    private repo: Repository<TeamRegistration>;
+    private seasonRepo: Repository<Seasons>;
+    private teamRepo: Repository<Teams>;
+    private playerRepo: Repository<Players>;
+    private userRepo: Repository<User>;
+    private regionService = new RegionService();
+    private userService = new UserService();
+
+    constructor() {
+        this.repo = AppDataSource.getRepository(TeamRegistration);
+        this.seasonRepo = AppDataSource.getRepository(Seasons);
+        this.teamRepo = AppDataSource.getRepository(Teams);
+        this.playerRepo = AppDataSource.getRepository(Players);
+        this.userRepo = AppDataSource.getRepository(User);
+    }
+
+    private async openSeasonForRegion(regionCode: RegionCode): Promise<{ season: Seasons; regionId: number }> {
+        const region = await this.regionService.requireRegionByCode(regionCode);
+        const open = await this.seasonRepo.find({
+            where: { regionId: region.id, registrationsOpen: true },
+            order: { seasonNumber: "DESC" },
+        });
+        if (open.length === 0) {
+            throw new ConflictError("Team registrations are not open for this region");
+        }
+        if (open.length > 1) {
+            throw new ConflictError("Multiple seasons have registrations open; ask an admin to fix this");
+        }
+        return { season: open[0], regionId: region.id };
+    }
+
+    async submit(userId: number, dto: CreateTeamRegistrationDto): Promise<TeamRegistration> {
+        const { season, regionId } = await this.openSeasonForRegion(dto.region);
+
+        const active = await this.repo.findOne({
+            where: [
+                { submittedByUserId: userId, seasonId: season.id, status: "pending" },
+                { submittedByUserId: userId, seasonId: season.id, status: "conflict" },
+                { submittedByUserId: userId, seasonId: season.id, status: "accepted" },
+            ],
+        });
+        if (active?.status === "accepted") {
+            throw new ConflictError("You already have an accepted team in this region/season");
+        }
+        if (active) {
+            throw new ConflictError("You already have an active application for this region/season");
+        }
+
+        const row = new TeamRegistration();
+        row.submittedByUserId = userId;
+        row.regionId = regionId;
+        row.seasonId = season.id;
+        row.teamName = dto.teamName.trim();
+        row.hexColor = dto.hexColor;
+        row.brickColor = dto.brickColor.trim();
+        row.captainDiscord = dto.captainDiscord.trim();
+        row.captainRoblox = normalizeRobloxUsername(dto.captainRoblox);
+        row.viceDiscord = dto.viceDiscord.trim();
+        row.viceRoblox = normalizeRobloxUsername(dto.viceRoblox);
+        row.roster = normalizeRoster(dto.roster);
+        row.agreeCivilScheduling = true;
+        row.confidentWillParticipate = true;
+        row.priorLeagueExperience = dto.priorLeagueExperience?.trim() || null;
+        row.logoJerseyAck = true;
+        row.status = "pending";
+
+        return await this.repo.save(row);
+    }
+
+    async updatePending(userId: number, id: number, dto: UpdateTeamRegistrationDto): Promise<TeamRegistration> {
+        const row = await this.requireOwned(userId, id);
+        if (row.status !== "pending") {
+            throw new ConflictError("Only pending applications can be edited");
+        }
+
+        if (dto.teamName !== undefined) row.teamName = dto.teamName.trim();
+        if (dto.hexColor !== undefined) row.hexColor = dto.hexColor;
+        if (dto.brickColor !== undefined) row.brickColor = dto.brickColor.trim();
+        if (dto.captainDiscord !== undefined) row.captainDiscord = dto.captainDiscord.trim();
+        if (dto.captainRoblox !== undefined) row.captainRoblox = normalizeRobloxUsername(dto.captainRoblox);
+        if (dto.viceDiscord !== undefined) row.viceDiscord = dto.viceDiscord.trim();
+        if (dto.viceRoblox !== undefined) row.viceRoblox = normalizeRobloxUsername(dto.viceRoblox);
+        if (dto.roster !== undefined) row.roster = normalizeRoster(dto.roster);
+        if (dto.priorLeagueExperience !== undefined) {
+            row.priorLeagueExperience = dto.priorLeagueExperience?.trim() || null;
+        }
+        if (dto.agreeCivilScheduling !== undefined) row.agreeCivilScheduling = dto.agreeCivilScheduling;
+        if (dto.confidentWillParticipate !== undefined) {
+            row.confidentWillParticipate = dto.confidentWillParticipate;
+        }
+        if (dto.logoJerseyAck !== undefined) row.logoJerseyAck = dto.logoJerseyAck;
+
+        return await this.repo.save(row);
+    }
+
+    async withdraw(userId: number, id: number): Promise<void> {
+        const row = await this.requireOwned(userId, id);
+        if (row.status !== "pending" && row.status !== "conflict") {
+            throw new ConflictError("Only pending or conflict applications can be withdrawn");
+        }
+        await this.repo.remove(row);
+    }
+
+    private async requireOwned(userId: number, id: number): Promise<TeamRegistration> {
+        const row = await this.repo.findOne({ where: { id } });
+        if (!row) throw new NotFoundError("Registration not found");
+        if (row.submittedByUserId !== userId) throw new UnauthorizedError("Not your registration");
+        return row;
+    }
+
+    async list(filters: {
+        regionId?: number;
+        region?: RegionCode;
+        seasonId?: number;
+        status?: string;
+    }): Promise<TeamRegistration[]> {
+        let regionId = filters.regionId;
+        if (!regionId && filters.region) {
+            regionId = (await this.regionService.requireRegionByCode(filters.region)).id;
+        }
+
+        const qb = this.repo
+            .createQueryBuilder("r")
+            .leftJoinAndSelect("r.region", "region")
+            .leftJoinAndSelect("r.season", "season")
+            .leftJoinAndSelect("r.submittedBy", "submittedBy")
+            .orderBy("CASE WHEN r.status = 'accepted' THEN 0 ELSE 1 END", "ASC")
+            .addOrderBy("r.createdAt", "ASC");
+
+        if (regionId) qb.andWhere("r.regionId = :regionId", { regionId });
+        if (filters.seasonId) qb.andWhere("r.seasonId = :seasonId", { seasonId: filters.seasonId });
+        if (filters.status) qb.andWhere("r.status = :status", { status: filters.status });
+
+        return qb.getMany();
+    }
+
+    toPublicDto(row: TeamRegistration) {
+        return {
+            id: row.id,
+            teamName: row.teamName,
+            captainDiscord: row.captainDiscord,
+            captainRoblox: row.captainRoblox,
+            status: row.status,
+            regionId: row.regionId,
+            seasonId: row.seasonId,
+            region: row.region,
+            season: row.season
+                ? {
+                      id: row.season.id,
+                      seasonNumber: row.season.seasonNumber,
+                      startDate: row.season.startDate,
+                      maxTeams: row.season.maxTeams,
+                      registrationsOpen: row.season.registrationsOpen,
+                  }
+                : undefined,
+            createdAt: row.createdAt,
+        };
+    }
+
+    toDetailDto(row: TeamRegistration, includeAdmin = false) {
+        const base = {
+            ...this.toPublicDto(row),
+            hexColor: row.hexColor,
+            brickColor: row.brickColor,
+            viceDiscord: row.viceDiscord,
+            viceRoblox: row.viceRoblox,
+            roster: row.roster,
+            agreeCivilScheduling: row.agreeCivilScheduling,
+            confidentWillParticipate: row.confidentWillParticipate,
+            priorLeagueExperience: row.priorLeagueExperience,
+            logoJerseyAck: row.logoJerseyAck,
+            createdTeamId: row.createdTeamId,
+            captainLinkPending: row.captainLinkPending,
+            submittedByUserId: row.submittedByUserId,
+            submittedBy: row.submittedBy
+                ? { id: row.submittedBy.id, username: row.submittedBy.username }
+                : undefined,
+        };
+        if (includeAdmin) {
+            return { ...base, conflictPayload: row.conflictPayload };
+        }
+        return base;
+    }
+
+    async getById(id: number): Promise<TeamRegistration> {
+        const row = await this.repo.findOne({
+            where: { id },
+            relations: ["region", "season", "submittedBy", "createdTeam"],
+        });
+        if (!row) throw new NotFoundError("Registration not found");
+        return row;
+    }
+
+    async summary(region?: RegionCode, seasonId?: number) {
+        let regionId: number | undefined;
+        if (region) regionId = (await this.regionService.requireRegionByCode(region)).id;
+
+        let season: Seasons | null = null;
+        if (seasonId) {
+            season = await this.seasonRepo.findOne({ where: { id: seasonId } });
+        } else if (regionId) {
+            season = await this.seasonRepo.findOne({
+                where: { regionId, registrationsOpen: true },
+                order: { seasonNumber: "DESC" },
+            });
+            if (!season) {
+                season = await this.seasonRepo.findOne({
+                    where: { regionId },
+                    order: { seasonNumber: "DESC" },
+                });
+            }
+        }
+
+        if (!season) {
+            return { accepted: 0, spotsLeft: null, capacity: null, seasonId: null };
+        }
+
+        const accepted = await this.repo.count({
+            where: { seasonId: season.id, status: "accepted" },
+        });
+        const capacity = season.maxTeams;
+        const spotsLeft = capacity != null ? Math.max(0, capacity - accepted) : null;
+        return {
+            accepted,
+            spotsLeft,
+            capacity,
+            seasonId: season.id,
+            startDate: season.startDate,
+            registrationsOpen: season.registrationsOpen,
+            seasonNumber: season.seasonNumber,
+        };
+    }
+
+    async detectConflicts(
+        seasonId: number,
+        regionId: number,
+        teamName: string,
+        roster: RosterEntry[],
+        excludeTeamId?: number | null
+    ): Promise<RegistrationConflict[]> {
+        const conflicts: RegistrationConflict[] = [];
+
+        const nameTeam = await this.teamRepo.findOne({
+            where: { name: teamName, regionId, season: { id: seasonId } },
+            relations: ["season"],
+        });
+        if (nameTeam && nameTeam.id !== excludeTeamId) {
+            conflicts.push({ type: "name", teamName, existingTeamId: nameTeam.id });
+        }
+
+        for (const entry of roster) {
+            const roblox = normalizeRobloxUsername(entry.roblox);
+            const player = await this.playerRepo.findOne({
+                where: { robloxUsername: roblox },
+                relations: ["teams", "teams.season"],
+            });
+            if (!player?.teams?.length) continue;
+            const other = player.teams.find(
+                (t) => t.season?.id === seasonId && t.id !== excludeTeamId
+            );
+            if (other) {
+                conflicts.push({
+                    type: "player",
+                    roblox,
+                    existingTeamId: other.id,
+                    existingTeamName: other.name,
+                    playerId: player.id,
+                });
+            }
+        }
+
+        return conflicts;
+    }
+
+    async tryAccept(
+        id: number,
+        adminId: number,
+        options?: { teamName?: string; exclusions?: Set<string>; transfers?: Set<string> }
+    ): Promise<{ ok: true; registration: TeamRegistration; team: Teams } | { ok: false; conflicts: RegistrationConflict[]; registration: TeamRegistration }> {
+        const row = await this.getById(id);
+        if (row.status === "accepted") throw new ConflictError("Already accepted");
+        if (row.status === "denied") throw new ConflictError("Registration is denied");
+
+        let roster = [...row.roster];
+        const teamName = options?.teamName?.trim() || row.teamName;
+
+        if (options?.exclusions?.size) {
+            roster = roster.filter((r) => !options.exclusions!.has(normalizeRobloxUsername(r.roblox)));
+        }
+        if (roster.length < 10) {
+            throw new ConflictError("Roster must have at least 10 players after exclusions");
+        }
+
+        const conflicts = await this.detectConflicts(row.seasonId, row.regionId, teamName, roster, row.createdTeamId);
+        const remaining = conflicts.filter((c) => {
+            if (c.type === "player" && options?.transfers?.has(c.roblox)) return false;
+            if (c.type === "player" && options?.exclusions?.has(c.roblox)) return false;
+            if (c.type === "name" && options?.teamName && options.teamName.trim() !== row.teamName) {
+                return c.teamName === options.teamName.trim();
+            }
+            return true;
+        });
+
+        // Re-detect after applying transfer intent conceptually
+        const effectiveConflicts: RegistrationConflict[] = [];
+        for (const c of conflicts) {
+            if (c.type === "name") {
+                if (options?.teamName && normalizeRobloxUsername(options.teamName) !== normalizeRobloxUsername(row.teamName)) {
+                    const still = await this.teamRepo.findOne({
+                        where: { name: teamName, regionId: row.regionId, season: { id: row.seasonId } },
+                    });
+                    if (still) effectiveConflicts.push({ type: "name", teamName, existingTeamId: still.id });
+                } else {
+                    effectiveConflicts.push(c);
+                }
+            } else if (c.type === "player") {
+                if (options?.exclusions?.has(c.roblox)) continue;
+                if (options?.transfers?.has(c.roblox)) continue;
+                effectiveConflicts.push(c);
+            }
+        }
+
+        if (effectiveConflicts.length > 0) {
+            row.status = "conflict";
+            row.conflictPayload = { conflicts: effectiveConflicts };
+            if (options?.teamName) row.teamName = teamName;
+            await this.repo.save(row);
+            return { ok: false, conflicts: effectiveConflicts, registration: row };
+        }
+
+        // Apply transfers
+        if (options?.transfers?.size) {
+            for (const roblox of options.transfers) {
+                const player = await this.playerRepo.findOne({
+                    where: { robloxUsername: roblox },
+                    relations: ["teams", "teams.season"],
+                });
+                if (!player) continue;
+                player.teams = (player.teams || []).filter((t) => t.season?.id !== row.seasonId);
+                await this.playerRepo.save(player);
+            }
+        }
+
+        if (options?.teamName) row.teamName = teamName;
+        row.roster = roster;
+
+        const team = new Teams();
+        team.name = row.teamName;
+        team.hexColor = row.hexColor;
+        team.brickColor = row.brickColor;
+        team.regionId = row.regionId;
+        team.season = row.season;
+        team.captainEditEnabled = true;
+        team.placement = "Didnt make playoffs";
+
+        const linkedCaptain = await this.userRepo.findOne({
+            where: { robloxUsername: row.captainRoblox },
+        });
+        if (linkedCaptain) {
+            team.captainUserId = linkedCaptain.id;
+            row.captainLinkPending = false;
+        } else {
+            team.captainUserId = row.submittedByUserId;
+            row.captainLinkPending = true;
+        }
+
+        const players: Players[] = [];
+        for (const entry of roster) {
+            let player = await this.playerRepo.findOne({
+                where: { robloxUsername: entry.roblox },
+                relations: ["teams"],
+            });
+            if (!player) {
+                player = new Players();
+                player.name = entry.roblox;
+                player.robloxUsername = entry.roblox;
+                player.discordUsername = entry.discord;
+                player.position = "N/A";
+                player.teams = [];
+            } else {
+                player.discordUsername = entry.discord;
+                if (!player.teams) player.teams = [];
+            }
+            const linkedUser = await this.userRepo.findOne({ where: { robloxUsername: entry.roblox } });
+            if (linkedUser) {
+                player.userId = linkedUser.id;
+                player.robloxUserId = linkedUser.robloxUserId;
+            }
+            players.push(await this.playerRepo.save(player));
+        }
+
+        team.players = players;
+        const savedTeam = await this.teamRepo.save(team);
+
+        row.status = "accepted";
+        row.createdTeamId = savedTeam.id;
+        row.conflictPayload = null;
+        await this.repo.save(row);
+
+        const captainId = team.captainUserId!;
+        await this.userService.promoteRoleIfUser(captainId, "captain", adminId);
+
+        // TODO: Google Sheets sync (name, brick, hex, region) when sheet exists
+
+        return { ok: true, registration: row, team: savedTeam };
+    }
+
+    async resolve(id: number, adminId: number, dto: ResolveRegistrationDto) {
+        if (dto.decision === "pending") {
+            const row = await this.getById(id);
+            row.status = "pending";
+            row.conflictPayload = null;
+            return { registration: await this.repo.save(row) };
+        }
+        if (dto.decision === "denied") {
+            return { registration: await this.deny(id) };
+        }
+
+        const exclusions = new Set(
+            (dto.players || []).filter((p) => p.action === "exclude").map((p) => normalizeRobloxUsername(p.roblox))
+        );
+        const transfers = new Set(
+            (dto.players || []).filter((p) => p.action === "transfer").map((p) => normalizeRobloxUsername(p.roblox))
+        );
+
+        return this.tryAccept(id, adminId, {
+            teamName: dto.teamName,
+            exclusions,
+            transfers,
+        });
+    }
+
+    async deny(id: number): Promise<TeamRegistration> {
+        const row = await this.getById(id);
+        if (row.status === "accepted") {
+            throw new ConflictError("Use revoke while registrations are open to undo an accepted application");
+        }
+        row.status = "denied";
+        row.conflictPayload = null;
+        return await this.repo.save(row);
+    }
+
+    async revoke(id: number): Promise<TeamRegistration> {
+        const row = await this.getById(id);
+        if (row.status !== "accepted") {
+            throw new ConflictError("Only accepted registrations can be revoked");
+        }
+        const season = await this.seasonRepo.findOne({ where: { id: row.seasonId } });
+        if (!season?.registrationsOpen) {
+            throw new ConflictError(
+                "Application process is closed; leave the team archived for season records"
+            );
+        }
+
+        row.status = "denied";
+        // Keep created team for history but clear link optional — plan says prefer status change;
+        // leave team as-is in DB for archive during open period we still deny the registration.
+        await this.repo.save(row);
+        return row;
+    }
+}

--- a/BE/src/modules/teams/team.controller.ts
+++ b/BE/src/modules/teams/team.controller.ts
@@ -200,4 +200,26 @@ export class TeamController {
             next(error);
         }
     };
+
+    staffUpdate = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (!req.user?.id) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            const team = await this.teamService.staffUpdateTeam(parseInt(req.params.id), req.user.id, req.body);
+            res.json(this.teamService.enrichTeamWithCanEdit(team, req.user.id));
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    adminFlags = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const team = await this.teamService.adminPatchTeamFlags(parseInt(req.params.id), req.body);
+            res.json(team);
+        } catch (error) {
+            next(error);
+        }
+    };
 }

--- a/BE/src/modules/teams/team.routes.ts
+++ b/BE/src/modules/teams/team.routes.ts
@@ -4,6 +4,7 @@ import { authenticateCombined } from '../../middleware/combinedAuth.js';
 import { authorizeRoles } from '../../middleware/authorizeRoles.js';
 import { createTeamSchema, updateTeamSchema } from './teams.schema.js';
 import { TeamController } from './team.controller.js';
+import { staffTeamUpdateSchema, adminTeamFlagsSchema } from '../team-registrations/team-registration.schema.js';
 
 export function registerTeamRoutes(app: Application): void {
     const router = Router();
@@ -23,6 +24,23 @@ export function registerTeamRoutes(app: Application): void {
     router.get('/name/:name/players', teamController.getTeamPlayersByName);
     router.get('/:teamId/players', teamController.getTeamPlayers);
     router.get('/name/:name', teamController.getTeamsByName.bind(teamController));
+
+    // Captain / VC / CC staff edit
+    router.patch(
+        '/:id/staff',
+        authenticateCombined,
+        validate(staffTeamUpdateSchema),
+        teamController.staffUpdate
+    );
+
+    // Admin flags / staff override
+    router.patch(
+        '/:id/flags',
+        authenticateCombined,
+        authorizeRoles("admin", "superadmin"),
+        validate(adminTeamFlagsSchema),
+        teamController.adminFlags
+    );
     
     // UPDATE/DELETE routes - PROTECTED
     router.put('/:id', authenticateCombined, authorizeRoles("admin", "superadmin"), validate(updateTeamSchema), teamController.updateTeam);

--- a/BE/src/modules/teams/team.service.ts
+++ b/BE/src/modules/teams/team.service.ts
@@ -9,10 +9,15 @@ import { MultipleGamesNotFoundError } from '../../errors/MultipleGamesNotFoundEr
 import { MultiplePlayersNotFoundError } from '../../errors/MultiplePlayersNotFoundError.js';
 import { DuplicateError } from '../../errors/DuplicateError.js';
 import { NotFoundError } from '../../errors/NotFoundError.js';
+import { ConflictError } from '../../errors/ConflictError.js';
+import { UnauthorizedError } from '../../errors/UnauthorizedError.js';
 import { CreateTeamDto, UpdateTeamDto, CreateMultipleTeamsDto } from './teams.schema.js';
 import { PaginationParams, SortParams } from '../../utils/pagination.js';
 import { RegionService } from '../regions/region.service.js';
 import { RegionCode } from '../regions/region.entity.js';
+import { User } from '../user/user.entity.js';
+import { UserService } from '../user/user.service.js';
+import { normalizeRobloxUsername } from '../../middleware/authValidation.js';
 
 export interface TeamFilters {
     search?: string;
@@ -507,5 +512,180 @@ export class TeamService {
         }
 
         await this.teamRepository.remove(team);
+    }
+
+    async getTeamForStaff(id: number): Promise<Teams> {
+        const team = await this.teamRepository.findOne({
+            where: { id },
+            relations: ["season", "players", "captainUser", "viceCaptainUser", "courtCaptainUser", "region"],
+        });
+        if (!team) throw new NotFoundError(`Team with ID ${id} not found`);
+        return team;
+    }
+
+    canStaffEdit(team: Teams, userId: number): {
+        allowed: boolean;
+        role: "captain" | "vice_captain" | "court_captain" | null;
+        reason?: string;
+    } {
+        if (!team.season?.captainEditEnabled) {
+            return { allowed: false, role: null, reason: "Captain editing is disabled for this season" };
+        }
+        if (!team.captainEditEnabled) {
+            return { allowed: false, role: null, reason: "Captain editing is disabled for this team" };
+        }
+        if (team.captainUserId === userId) return { allowed: true, role: "captain" };
+        if (team.viceCaptainUserId === userId) return { allowed: true, role: "vice_captain" };
+        if (team.courtCaptainUserId === userId) return { allowed: true, role: "court_captain" };
+        return { allowed: false, role: null, reason: "You are not staff on this team" };
+    }
+
+    private async assertLinkedRosterUser(team: Teams, userId: number): Promise<User> {
+        const userRepo = AppDataSource.getRepository(User);
+        const user = await userRepo.findOne({ where: { id: userId } });
+        if (!user?.robloxUsername) {
+            throw new ConflictError("Target user must have a linked Roblox account");
+        }
+        const onRoster = (team.players || []).some(
+            (p) => p.robloxUsername === user.robloxUsername || p.userId === userId
+        );
+        if (!onRoster) {
+            throw new ConflictError("Target user must be on the team roster with a linked Roblox account");
+        }
+        return user;
+    }
+
+    async staffUpdateTeam(
+        teamId: number,
+        actorId: number,
+        body: {
+            name?: string;
+            hexColor?: string | null;
+            brickColor?: string | null;
+            logoUrl?: string | null;
+            roster?: { discord: string; roblox: string }[];
+            captainUserId?: number | null;
+            viceCaptainUserId?: number | null;
+            courtCaptainUserId?: number | null;
+        }
+    ): Promise<Teams> {
+        const team = await this.getTeamForStaff(teamId);
+        const gate = this.canStaffEdit(team, actorId);
+        if (!gate.allowed || !gate.role) {
+            throw new UnauthorizedError(gate.reason || "Forbidden");
+        }
+
+        const role = gate.role;
+
+        if (body.name !== undefined) {
+            if (role !== "captain") throw new UnauthorizedError("Only the captain can rename the team");
+            const clash = await this.teamRepository.findOne({
+                where: { name: body.name.trim(), regionId: team.regionId, season: { id: team.season.id } },
+            });
+            if (clash && clash.id !== team.id) {
+                throw new ConflictError(`A team named "${body.name}" already exists in this season`);
+            }
+            team.name = body.name.trim();
+        }
+
+        if (body.hexColor !== undefined || body.brickColor !== undefined || body.logoUrl !== undefined) {
+            if (body.hexColor !== undefined) team.hexColor = body.hexColor;
+            if (body.brickColor !== undefined) team.brickColor = body.brickColor;
+            if (body.logoUrl !== undefined) team.logoUrl = body.logoUrl ?? undefined;
+        }
+
+        if (body.roster !== undefined) {
+            if (body.roster.length < 10) throw new ConflictError("Roster must have at least 10 players");
+            const players: Players[] = [];
+            for (const entry of body.roster) {
+                const roblox = normalizeRobloxUsername(entry.roblox);
+                const existing = await this.playerRepository.findOne({
+                    where: { robloxUsername: roblox },
+                    relations: ["teams", "teams.season"],
+                });
+                if (existing?.teams?.some((t) => t.season?.id === team.season.id && t.id !== team.id)) {
+                    throw new ConflictError(`Player ${roblox} is already on another team this season`);
+                }
+                let player = existing;
+                if (!player) {
+                    player = new Players();
+                    player.name = roblox;
+                    player.robloxUsername = roblox;
+                    player.discordUsername = entry.discord.trim();
+                    player.position = "N/A";
+                    player.teams = [];
+                } else {
+                    player.discordUsername = entry.discord.trim();
+                }
+                players.push(await this.playerRepository.save(player));
+            }
+            team.players = players;
+        }
+
+        const userService = new UserService();
+
+        if (body.captainUserId !== undefined) {
+            if (role !== "captain") throw new UnauthorizedError("Only the captain can transfer captaincy");
+            if (body.captainUserId != null) {
+                await this.assertLinkedRosterUser(team, body.captainUserId);
+                team.captainUserId = body.captainUserId;
+                await userService.promoteRoleIfUser(body.captainUserId, "captain", actorId);
+            }
+        }
+
+        if (body.viceCaptainUserId !== undefined) {
+            if (role !== "captain") throw new UnauthorizedError("Only the captain can assign vice captain");
+            if (body.viceCaptainUserId != null) {
+                await this.assertLinkedRosterUser(team, body.viceCaptainUserId);
+                team.viceCaptainUserId = body.viceCaptainUserId;
+                await userService.promoteRoleIfUser(body.viceCaptainUserId, "vice_captain", actorId);
+            } else {
+                team.viceCaptainUserId = null;
+            }
+        }
+
+        if (body.courtCaptainUserId !== undefined) {
+            if (role !== "captain" && role !== "vice_captain") {
+                throw new UnauthorizedError("Only captain or vice captain can assign court captain");
+            }
+            if (body.courtCaptainUserId != null) {
+                await this.assertLinkedRosterUser(team, body.courtCaptainUserId);
+                team.courtCaptainUserId = body.courtCaptainUserId;
+                await userService.promoteRoleIfUser(body.courtCaptainUserId, "court_captain", actorId);
+            } else {
+                team.courtCaptainUserId = null;
+            }
+        }
+
+        await this.teamRepository.save(team);
+        return this.getTeamForStaff(teamId);
+    }
+
+    async adminPatchTeamFlags(
+        teamId: number,
+        body: {
+            captainEditEnabled?: boolean;
+            hexColor?: string | null;
+            brickColor?: string | null;
+            captainUserId?: number | null;
+            viceCaptainUserId?: number | null;
+            courtCaptainUserId?: number | null;
+        }
+    ): Promise<Teams> {
+        const team = await this.getTeamForStaff(teamId);
+        if (body.captainEditEnabled !== undefined) team.captainEditEnabled = body.captainEditEnabled;
+        if (body.hexColor !== undefined) team.hexColor = body.hexColor;
+        if (body.brickColor !== undefined) team.brickColor = body.brickColor;
+        if (body.captainUserId !== undefined) team.captainUserId = body.captainUserId;
+        if (body.viceCaptainUserId !== undefined) team.viceCaptainUserId = body.viceCaptainUserId;
+        if (body.courtCaptainUserId !== undefined) team.courtCaptainUserId = body.courtCaptainUserId;
+        await this.teamRepository.save(team);
+        return this.getTeamForStaff(teamId);
+    }
+
+    enrichTeamWithCanEdit(team: Teams, userId?: number) {
+        if (!userId) return { ...team, captainCanEdit: false, staffRole: null };
+        const gate = this.canStaffEdit(team, userId);
+        return { ...team, captainCanEdit: gate.allowed, staffRole: gate.role };
     }
 }

--- a/BE/src/scripts/run-migrations.ts
+++ b/BE/src/scripts/run-migrations.ts
@@ -6,6 +6,7 @@ import { env, getPostgresConnectionOptions } from "../config/env.js";
 // Get current directory for ES modules
 const currentFile = fileURLToPath(import.meta.url);
 const currentDir = dirname(currentFile);
+const migrationsDir = join(currentDir, "..", "migrations");
 
 console.log("==========================================");
 console.log("MIGRATION PROCESS STARTING");
@@ -29,7 +30,7 @@ const AppDataSource = new DataSource({
     type: "postgres",
     ...getPostgresConnectionOptions(env),
     entities: [join(currentDir, "..", "modules", "**", "*.entity.{js,ts}")],
-    migrations: [join(currentDir, "*.{js,ts}")],
+    migrations: [join(migrationsDir, "*.{js,ts}")],
     migrationsTransactionMode: "each",
     synchronize: false,
     logging: true,

--- a/BE/start.sh
+++ b/BE/start.sh
@@ -21,16 +21,16 @@ if [ -n "$COOLIFY_URL" ]; then
 fi
 echo "=========================================="
 
-# Run migrations in production only; local docker dev syncs schema on startup
-if [ "$NODE_ENV" = "production" ]; then
+# Migrations for real DBs; local Docker may opt into TYPEORM_SYNCHRONIZE=true instead.
+if [ "$TYPEORM_SYNCHRONIZE" = "true" ]; then
+    echo "Skipping migrations (TYPEORM_SYNCHRONIZE=true — schema syncs on startup)."
+else
     echo "Running database migrations..."
-    if ! node --es-module-specifier-resolution=node dist/migrations/run-migrations.js; then
+    if ! node --es-module-specifier-resolution=node dist/scripts/run-migrations.js; then
         echo "Error: Database migrations failed!"
         exit 1
     fi
     echo "Database migrations completed successfully."
-else
-    echo "Skipping migrations in development (schema syncs on startup)."
 fi
 
 # Start the application

--- a/FE/nginx.conf
+++ b/FE/nginx.conf
@@ -1,4 +1,4 @@
-﻿server {
+server {
     listen 8080;
     server_name _;
     root /usr/share/nginx/html;

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -45,6 +45,10 @@ const AwardsPage        = lazy(() => import("./components/portal/AwardsPage"));
 const CreateArticle     = lazy(() => import("./components/CreateArticle"));
 const ArticlesPage      = lazy(() => import("./components/portal/ArticlesPage"));
 const ApplicationsPage  = lazy(() => import("./components/portal/ApplicationsPage"));
+const RegistrationsHubPage = lazy(() => import("./components/portal/RegistrationsHubPage"));
+const TeamRegistrations = lazy(() => import("./components/TeamRegistrations"));
+const TeamRegister = lazy(() => import("./components/TeamRegister"));
+const TeamRegistrationDetail = lazy(() => import("./components/TeamRegistrationDetail"));
 const StatsLeaderboard  = lazy(() => import("./components/StatsLeaderboard"));
 const FAQ               = lazy(() => import("./components/FAQ"));
 const RecordsPage       = lazy(() => import("./components/RecordsPage"));
@@ -69,6 +73,9 @@ const App: React.FC = () => (
           <Route path="/about" element={<About />} />
           <Route path="/players" element={<Players />} />
           <Route path="/teams" element={<Teams />} />
+          <Route path="/teams/registrations" element={<TeamRegistrations />} />
+          <Route path="/teams/registrations/:id" element={<TeamRegistrationDetail />} />
+          <Route path="/teams/register" element={<TeamRegister />} />
           <Route path="/teams/:teamName" element={<SingleTeam />} />
           <Route path="/games" element={<Games />} />
           <Route path="/games/:id" element={<SingleGame />} />
@@ -117,6 +124,7 @@ const App: React.FC = () => (
             <Route path="awards" element={<AwardsPage />} />
             <Route path="articles" element={<ArticlesPage />} />
             <Route path="applications" element={<ApplicationsPage />} />
+            <Route path="registrations" element={<RegistrationsHubPage />} />
           </Route>
         </Routes>
         </Suspense>

--- a/FE/src/components/Login.tsx
+++ b/FE/src/components/Login.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useLogin } from "../hooks/useLogin";
+import { startRobloxOAuth } from "../hooks/useTeamRegistrations";
 import "../styles/Login.css";
 
 const LoginPage: React.FC = () =>
@@ -14,6 +15,17 @@ const LoginPage: React.FC = () =>
     // form state
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
+    const [oauthError, setOauthError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get("roblox") === "error") {
+            setOauthError(params.get("message") || "Roblox login failed");
+        }
+        if (params.get("roblox") === "need_signup") {
+            setOauthError("No account linked to that Roblox user. Sign up with Roblox instead.");
+        }
+    }, []);
 
     // on form submit
     const handleSubmit = async (e: React.FormEvent) =>
@@ -31,7 +43,7 @@ const LoginPage: React.FC = () =>
     return (
         <div className="auth-container">
             <h2>Login</h2>
-            {error && <div className="auth-error">{error}</div>}
+            {(error || oauthError) && <div className="auth-error">{error || oauthError}</div>}
             <form onSubmit={handleSubmit} className="auth-form">
                 <label>
                     Username
@@ -55,6 +67,13 @@ const LoginPage: React.FC = () =>
                     {loading ? "Logging in…" : "Login"}
                 </button>
             </form>
+            <button
+                type="button"
+                className="auth-sso-btn"
+                onClick={() => void startRobloxOAuth("login").catch((e) => setOauthError(String(e.message || e)))}
+            >
+                Log in with Roblox
+            </button>
             <p>
                 Don’t have an account?{" "}
                 <Link className="auth-link" to="/signup">

--- a/FE/src/components/RegStatusBadge.tsx
+++ b/FE/src/components/RegStatusBadge.tsx
@@ -1,0 +1,14 @@
+import type { TeamRegistrationStatus } from "../types/interfaces";
+
+const STATUS_LABEL: Record<TeamRegistrationStatus, string> = {
+  pending: "Pending",
+  conflict: "Conflict",
+  accepted: "Accepted",
+  denied: "Denied",
+};
+
+export const REGISTRATION_STATUSES = Object.keys(STATUS_LABEL) as TeamRegistrationStatus[];
+
+export function RegStatusBadge({ status }: { status: TeamRegistrationStatus }) {
+  return <span className={`reg-status-badge ${status}`}>{STATUS_LABEL[status]}</span>;
+}

--- a/FE/src/components/SignUp.tsx
+++ b/FE/src/components/SignUp.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Link, useNavigate }        from "react-router-dom";
 import { useSignup }          from "../hooks/useSignUp";
+import { startRobloxOAuth } from "../hooks/useTeamRegistrations";
 import "../styles/Login.css";
 
 const SignupPage: React.FC = () =>
@@ -104,6 +105,14 @@ const SignupPage: React.FC = () =>
                     {loading ? "Signing up…" : "Sign Up"}
                 </button>
             </form>
+
+            <button
+                type="button"
+                className="auth-sso-btn"
+                onClick={() => void startRobloxOAuth("signup").catch((e) => alert(String(e.message || e)))}
+            >
+                Sign up with Roblox
+            </button>
 
             <p>
                 Already have an account?{' '}

--- a/FE/src/components/Single/SingleTeam.tsx
+++ b/FE/src/components/Single/SingleTeam.tsx
@@ -6,6 +6,8 @@ import { useSingleTeam }                             from '../../hooks/allFetch'
 import "../../styles/SingleTeam.css";
 import SEO from "../SEO";
 import { formatGameStage } from "../../utils/gameLabels";
+import TeamStaffEdit from "../TeamStaffEdit";
+import "../../styles/TeamRegistrations.css";
 
 const SingleTeam: React.FC = () =>
 {
@@ -185,6 +187,8 @@ const SingleTeam: React.FC = () =>
             <p>Season: {team.season.seasonNumber ?? 'N/A'}</p>
             <p>Playoff Games Played: {team.games?.length ?? 0}</p>
             <p>Placement: {team.placement}</p>
+
+            <TeamStaffEdit team={team} />
 
             {/* Players Section */}
             <div className="players-list">

--- a/FE/src/components/TeamRegister.tsx
+++ b/FE/src/components/TeamRegister.tsx
@@ -1,0 +1,238 @@
+import React, { useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../context/authContext";
+import { useRegion } from "../context/regionContext";
+import { authFetch } from "../hooks/authFetch";
+import { BACKEND_URL } from "../constants/api";
+import { useRegistrationSummary } from "../hooks/useTeamRegistrations";
+import type { RegionCode, TeamRegistrationRosterEntry } from "../types/interfaces";
+import "../styles/TeamRegistrations.css";
+
+const emptyRoster = (): TeamRegistrationRosterEntry[] =>
+  Array.from({ length: 10 }, () => ({ discord: "", roblox: "" }));
+
+const TeamRegister: React.FC = () => {
+  const { isAuthenticated, loading: authLoading } = useAuth();
+  const { activeRegion } = useRegion();
+  const navigate = useNavigate();
+  const region = (activeRegion?.code || "na") as RegionCode;
+  const summary = useRegistrationSummary(region);
+
+  const [teamName, setTeamName] = useState("");
+  const [hexColor, setHexColor] = useState("#2D3C50");
+  const [brickColor, setBrickColor] = useState("");
+  const [captainDiscord, setCaptainDiscord] = useState("");
+  const [captainRoblox, setCaptainRoblox] = useState("");
+  const [viceDiscord, setViceDiscord] = useState("");
+  const [viceRoblox, setViceRoblox] = useState("");
+  const [roster, setRoster] = useState(emptyRoster);
+  const [agreeCivil, setAgreeCivil] = useState(false);
+  const [confident, setConfident] = useState(false);
+  const [experience, setExperience] = useState("");
+  const [logoAck, setLogoAck] = useState(false);
+  const [regionCode, setRegionCode] = useState<RegionCode>(region);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const startLabel = useMemo(() => {
+    if (summary?.startDate) {
+      try {
+        return new Date(summary.startDate).toLocaleDateString();
+      } catch {
+        return "TBD";
+      }
+    }
+    return "TBD";
+  }, [summary?.startDate]);
+
+  if (authLoading) return <div className="team-reg-form">Loading…</div>;
+
+  if (!isAuthenticated) {
+    return (
+      <div className="team-reg-form">
+        <h1>Register a team</h1>
+        <p>
+          You must be logged in to submit a team application.{" "}
+          <Link to="/login">Log in</Link> or <Link to="/signup">sign up</Link>.
+        </p>
+      </div>
+    );
+  }
+
+  const updateRoster = (index: number, field: "discord" | "roblox", value: string) => {
+    setRoster((prev) => prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)));
+  };
+
+  const syncCaptainViceIntoRoster = (next: TeamRegistrationRosterEntry[]) => {
+    const copy = [...next];
+    if (captainDiscord && captainRoblox) {
+      copy[0] = { discord: captainDiscord, roblox: captainRoblox };
+    }
+    if (viceDiscord && viceRoblox) {
+      copy[1] = { discord: viceDiscord, roblox: viceRoblox };
+    }
+    return copy;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setSubmitting(true);
+    try {
+      const body = {
+        region: regionCode,
+        teamName,
+        hexColor: hexColor.startsWith("#") ? hexColor : `#${hexColor}`,
+        brickColor,
+        captainDiscord,
+        captainRoblox,
+        viceDiscord,
+        viceRoblox,
+        roster: syncCaptainViceIntoRoster(roster),
+        agreeCivilScheduling: true as const,
+        confidentWillParticipate: true as const,
+        priorLeagueExperience: experience || null,
+        logoJerseyAck: true as const,
+      };
+
+      if (!agreeCivil || !confident || !logoAck) {
+        throw new Error("Please answer all required yes/no and acknowledgment questions");
+      }
+
+      const res = await authFetch(`${BACKEND_URL}/api/team-registrations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || data.message || "Submission failed");
+      setSuccess("Application submitted!");
+      navigate(`/teams/registrations/${data.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Submission failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="team-reg-form">
+      <div className="team-regs-nav">
+        <Link to="/teams">League teams</Link>
+        <span>·</span>
+        <Link to="/teams/registrations">Team registrations</Link>
+        <span>·</span>
+        <span className="team-regs-nav-active">Register a team</span>
+      </div>
+
+      <h1>Register your team</h1>
+      <p>Anyone with a site account can submit. Season start: {startLabel}.</p>
+      {error && <p className="form-error">{error}</p>}
+      {success && <p className="form-success">{success}</p>}
+
+      <form onSubmit={handleSubmit}>
+        <fieldset>
+          <legend>Eligibility</legend>
+          <label>
+            <input type="checkbox" checked={agreeCivil} onChange={(e) => setAgreeCivil(e.target.checked)} /> Do
+            you understand and agree to be civil and accommodating when scheduling matches?
+          </label>
+          <label>
+            <input type="checkbox" checked={confident} onChange={(e) => setConfident(e.target.checked)} /> This
+            season is set to start on {startLabel}. Are you confident the team will still participate by then?
+          </label>
+          <label>
+            Region
+            <select value={regionCode} onChange={(e) => setRegionCode(e.target.value as RegionCode)}>
+              <option value="na">NA</option>
+              <option value="eu">EU</option>
+              <option value="as">AS</option>
+            </select>
+          </label>
+          <label>
+            Prior competitive Roblox Volleyball leagues (optional)
+            <textarea value={experience} onChange={(e) => setExperience(e.target.value)} rows={3} />
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Team</legend>
+          <label>
+            Team name
+            <input value={teamName} onChange={(e) => setTeamName(e.target.value)} required />
+          </label>
+          <label>
+            Hex color
+            <input value={hexColor} onChange={(e) => setHexColor(e.target.value)} required pattern="#?[0-9A-Fa-f]{6}" />
+          </label>
+          <label>
+            Brick color
+            <input value={brickColor} onChange={(e) => setBrickColor(e.target.value)} required />
+          </label>
+          <label>
+            <input type="checkbox" checked={logoAck} onChange={(e) => setLogoAck(e.target.checked)} /> I will
+            prepare a logo &amp; jerseys if accepted to RVL
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Captain &amp; Vice</legend>
+          <label>
+            Captain Discord
+            <input value={captainDiscord} onChange={(e) => setCaptainDiscord(e.target.value)} required />
+          </label>
+          <label>
+            Captain Roblox
+            <input value={captainRoblox} onChange={(e) => setCaptainRoblox(e.target.value)} required />
+          </label>
+          <label>
+            Vice Discord
+            <input value={viceDiscord} onChange={(e) => setViceDiscord(e.target.value)} required />
+          </label>
+          <label>
+            Vice Roblox
+            <input value={viceRoblox} onChange={(e) => setViceRoblox(e.target.value)} required />
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Roster (minimum 10, including captain &amp; vice)</legend>
+          {roster.map((row, i) => (
+            <div className="roster-row" key={i}>
+              <input
+                placeholder={`Player ${i + 1} Discord`}
+                value={row.discord}
+                onChange={(e) => updateRoster(i, "discord", e.target.value)}
+                required
+              />
+              <input
+                placeholder={`Player ${i + 1} Roblox`}
+                value={row.roblox}
+                onChange={(e) => updateRoster(i, "roblox", e.target.value)}
+                required
+              />
+              {i >= 10 && (
+                <button type="button" onClick={() => setRoster((r) => r.filter((_, idx) => idx !== i))}>
+                  Remove
+                </button>
+              )}
+            </div>
+          ))}
+          <button type="button" onClick={() => setRoster((r) => [...r, { discord: "", roblox: "" }])}>
+            Add player
+          </button>
+        </fieldset>
+
+        <div className="form-actions">
+          <button type="submit" disabled={submitting}>
+            {submitting ? "Submitting…" : "Submit application"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default TeamRegister;

--- a/FE/src/components/TeamRegister.tsx
+++ b/FE/src/components/TeamRegister.tsx
@@ -46,16 +46,38 @@ const TeamRegister: React.FC = () => {
     return "TBD";
   }, [summary?.startDate]);
 
-  if (authLoading) return <div className="team-reg-form">Loading…</div>;
+  if (authLoading) {
+    return (
+      <div className="team-reg-form">
+        <div className="team-reg-card team-reg-gate">
+          <p className="team-regs-muted">Loading…</p>
+        </div>
+      </div>
+    );
+  }
 
   if (!isAuthenticated) {
     return (
       <div className="team-reg-form">
-        <h1>Register a team</h1>
-        <p>
-          You must be logged in to submit a team application.{" "}
-          <Link to="/login">Log in</Link> or <Link to="/signup">sign up</Link>.
-        </p>
+        <div className="team-regs-nav">
+          <Link to="/teams">League teams</Link>
+          <span aria-hidden="true">·</span>
+          <Link to="/teams/registrations">Team registrations</Link>
+          <span aria-hidden="true">·</span>
+          <span className="team-regs-nav-active">Register a team</span>
+        </div>
+        <div className="team-reg-card team-reg-gate">
+          <h1>Register a team</h1>
+          <p>You must be logged in to submit a team application.</p>
+          <div className="team-reg-gate-links">
+            <Link className="team-regs-cta" to="/login">
+              Log in
+            </Link>
+            <Link className="team-regs-cta team-regs-cta--secondary" to="/signup">
+              Sign up
+            </Link>
+          </div>
+        </div>
       </div>
     );
   }
@@ -117,120 +139,201 @@ const TeamRegister: React.FC = () => {
     }
   };
 
+  const normalizedHex = hexColor.startsWith("#") ? hexColor : `#${hexColor}`;
+
   return (
     <div className="team-reg-form">
       <div className="team-regs-nav">
         <Link to="/teams">League teams</Link>
-        <span>·</span>
+        <span aria-hidden="true">·</span>
         <Link to="/teams/registrations">Team registrations</Link>
-        <span>·</span>
+        <span aria-hidden="true">·</span>
         <span className="team-regs-nav-active">Register a team</span>
       </div>
 
-      <h1>Register your team</h1>
-      <p>Anyone with a site account can submit. Season start: {startLabel}.</p>
-      {error && <p className="form-error">{error}</p>}
-      {success && <p className="form-success">{success}</p>}
+      <div className="team-reg-card">
+        <h1>Register your team</h1>
+        <p className="team-regs-muted">
+          Anyone with a site account can submit. Season start: <strong>{startLabel}</strong>.
+        </p>
 
-      <form onSubmit={handleSubmit}>
-        <fieldset>
-          <legend>Eligibility</legend>
-          <label>
-            <input type="checkbox" checked={agreeCivil} onChange={(e) => setAgreeCivil(e.target.checked)} /> Do
-            you understand and agree to be civil and accommodating when scheduling matches?
-          </label>
-          <label>
-            <input type="checkbox" checked={confident} onChange={(e) => setConfident(e.target.checked)} /> This
-            season is set to start on {startLabel}. Are you confident the team will still participate by then?
-          </label>
-          <label>
-            Region
-            <select value={regionCode} onChange={(e) => setRegionCode(e.target.value as RegionCode)}>
-              <option value="na">NA</option>
-              <option value="eu">EU</option>
-              <option value="as">AS</option>
-            </select>
-          </label>
-          <label>
-            Prior competitive Roblox Volleyball leagues (optional)
-            <textarea value={experience} onChange={(e) => setExperience(e.target.value)} rows={3} />
-          </label>
-        </fieldset>
+        {error && <p className="form-error">{error}</p>}
+        {success && <p className="form-success">{success}</p>}
 
-        <fieldset>
-          <legend>Team</legend>
-          <label>
-            Team name
-            <input value={teamName} onChange={(e) => setTeamName(e.target.value)} required />
-          </label>
-          <label>
-            Hex color
-            <input value={hexColor} onChange={(e) => setHexColor(e.target.value)} required pattern="#?[0-9A-Fa-f]{6}" />
-          </label>
-          <label>
-            Brick color
-            <input value={brickColor} onChange={(e) => setBrickColor(e.target.value)} required />
-          </label>
-          <label>
-            <input type="checkbox" checked={logoAck} onChange={(e) => setLogoAck(e.target.checked)} /> I will
-            prepare a logo &amp; jerseys if accepted to RVL
-          </label>
-        </fieldset>
-
-        <fieldset>
-          <legend>Captain &amp; Vice</legend>
-          <label>
-            Captain Discord
-            <input value={captainDiscord} onChange={(e) => setCaptainDiscord(e.target.value)} required />
-          </label>
-          <label>
-            Captain Roblox
-            <input value={captainRoblox} onChange={(e) => setCaptainRoblox(e.target.value)} required />
-          </label>
-          <label>
-            Vice Discord
-            <input value={viceDiscord} onChange={(e) => setViceDiscord(e.target.value)} required />
-          </label>
-          <label>
-            Vice Roblox
-            <input value={viceRoblox} onChange={(e) => setViceRoblox(e.target.value)} required />
-          </label>
-        </fieldset>
-
-        <fieldset>
-          <legend>Roster (minimum 10, including captain &amp; vice)</legend>
-          {roster.map((row, i) => (
-            <div className="roster-row" key={i}>
-              <input
-                placeholder={`Player ${i + 1} Discord`}
-                value={row.discord}
-                onChange={(e) => updateRoster(i, "discord", e.target.value)}
-                required
-              />
-              <input
-                placeholder={`Player ${i + 1} Roblox`}
-                value={row.roblox}
-                onChange={(e) => updateRoster(i, "roblox", e.target.value)}
-                required
-              />
-              {i >= 10 && (
-                <button type="button" onClick={() => setRoster((r) => r.filter((_, idx) => idx !== i))}>
-                  Remove
-                </button>
-              )}
+        <form onSubmit={handleSubmit}>
+          <section className="team-reg-section">
+            <h2>Eligibility</h2>
+            <label className="form-check">
+              <input type="checkbox" checked={agreeCivil} onChange={(e) => setAgreeCivil(e.target.checked)} />
+              <span>I understand and agree to be civil and accommodating when scheduling matches.</span>
+            </label>
+            <label className="form-check">
+              <input type="checkbox" checked={confident} onChange={(e) => setConfident(e.target.checked)} />
+              <span>
+                This season is set to start on {startLabel}. I am confident the team will still participate by then.
+              </span>
+            </label>
+            <div className="form-group">
+              <label htmlFor="team-reg-region">Region</label>
+              <select
+                id="team-reg-region"
+                value={regionCode}
+                onChange={(e) => setRegionCode(e.target.value as RegionCode)}
+              >
+                <option value="na">North American (NA)</option>
+                <option value="eu">European (EU)</option>
+                <option value="as">Asian (AS)</option>
+              </select>
             </div>
-          ))}
-          <button type="button" onClick={() => setRoster((r) => [...r, { discord: "", roblox: "" }])}>
-            Add player
-          </button>
-        </fieldset>
+            <div className="form-group">
+              <label htmlFor="team-reg-experience">Prior competitive Roblox Volleyball leagues (optional)</label>
+              <textarea
+                id="team-reg-experience"
+                value={experience}
+                onChange={(e) => setExperience(e.target.value)}
+                rows={3}
+                placeholder="e.g. previous RVL seasons, other leagues…"
+              />
+            </div>
+          </section>
 
-        <div className="form-actions">
-          <button type="submit" disabled={submitting}>
-            {submitting ? "Submitting…" : "Submit application"}
-          </button>
-        </div>
-      </form>
+          <section className="team-reg-section">
+            <h2>Team</h2>
+            <div className="form-group">
+              <label htmlFor="team-reg-name">Team name</label>
+              <input
+                id="team-reg-name"
+                value={teamName}
+                onChange={(e) => setTeamName(e.target.value)}
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="team-reg-hex">Hex color</label>
+              <div className="team-reg-color-row">
+                <input
+                  type="color"
+                  aria-label="Pick hex color"
+                  value={/^#[0-9A-Fa-f]{6}$/.test(normalizedHex) ? normalizedHex : "#2D3C50"}
+                  onChange={(e) => setHexColor(e.target.value)}
+                />
+                <input
+                  id="team-reg-hex"
+                  value={hexColor}
+                  onChange={(e) => setHexColor(e.target.value)}
+                  required
+                  pattern="#?[0-9A-Fa-f]{6}"
+                  placeholder="#2D3C50"
+                />
+              </div>
+            </div>
+            <div className="form-group">
+              <label htmlFor="team-reg-brick">Brick color</label>
+              <input
+                id="team-reg-brick"
+                value={brickColor}
+                onChange={(e) => setBrickColor(e.target.value)}
+                required
+                placeholder="Roblox brick color name"
+              />
+            </div>
+            <label className="form-check">
+              <input type="checkbox" checked={logoAck} onChange={(e) => setLogoAck(e.target.checked)} />
+              <span>I will prepare a logo &amp; jerseys if accepted to RVL</span>
+            </label>
+          </section>
+
+          <section className="team-reg-section">
+            <h2>Captain &amp; Vice</h2>
+            <div className="form-group">
+              <label htmlFor="team-reg-cap-discord">Captain Discord</label>
+              <input
+                id="team-reg-cap-discord"
+                value={captainDiscord}
+                onChange={(e) => setCaptainDiscord(e.target.value)}
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="team-reg-cap-roblox">Captain Roblox</label>
+              <input
+                id="team-reg-cap-roblox"
+                value={captainRoblox}
+                onChange={(e) => setCaptainRoblox(e.target.value)}
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="team-reg-vice-discord">Vice Discord</label>
+              <input
+                id="team-reg-vice-discord"
+                value={viceDiscord}
+                onChange={(e) => setViceDiscord(e.target.value)}
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="team-reg-vice-roblox">Vice Roblox</label>
+              <input
+                id="team-reg-vice-roblox"
+                value={viceRoblox}
+                onChange={(e) => setViceRoblox(e.target.value)}
+                required
+              />
+            </div>
+          </section>
+
+          <section className="team-reg-section">
+            <h2>Roster</h2>
+            <p className="team-regs-muted" style={{ marginBottom: "1rem" }}>
+              Minimum 10 players, including captain &amp; vice (rows 1–2).
+            </p>
+            {roster.map((row, i) => (
+              <div className="roster-row" key={i}>
+                <input
+                  placeholder={`Player ${i + 1} Discord`}
+                  aria-label={`Player ${i + 1} Discord`}
+                  value={row.discord}
+                  onChange={(e) => updateRoster(i, "discord", e.target.value)}
+                  required
+                />
+                <input
+                  placeholder={`Player ${i + 1} Roblox`}
+                  aria-label={`Player ${i + 1} Roblox`}
+                  value={row.roblox}
+                  onChange={(e) => updateRoster(i, "roblox", e.target.value)}
+                  required
+                />
+                {i >= 10 && (
+                  <button
+                    type="button"
+                    className="roster-row-remove"
+                    onClick={() => setRoster((r) => r.filter((_, idx) => idx !== i))}
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            ))}
+            <button
+              type="button"
+              className="team-regs-cta team-regs-cta--secondary"
+              onClick={() => setRoster((r) => [...r, { discord: "", roblox: "" }])}
+            >
+              Add player
+            </button>
+          </section>
+
+          <div className="form-actions">
+            <Link className="team-regs-cta team-regs-cta--secondary" to="/teams/registrations">
+              Cancel
+            </Link>
+            <button className="team-regs-cta" type="submit" disabled={submitting}>
+              {submitting ? "Submitting…" : "Submit application"}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 };

--- a/FE/src/components/TeamRegistrationDetail.tsx
+++ b/FE/src/components/TeamRegistrationDetail.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { authFetch } from "../hooks/authFetch";
+import { BACKEND_URL } from "../constants/api";
+import { useAuth } from "../context/authContext";
+import type { TeamRegistration } from "../types/interfaces";
+import "../styles/TeamRegistrations.css";
+
+const TeamRegistrationDetail: React.FC = () => {
+  const { id } = useParams();
+  const { user, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const [row, setRow] = useState<TeamRegistration | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await authFetch(`${BACKEND_URL}/api/team-registrations/${id}`);
+        if (!res.ok) throw new Error("Not found");
+        setRow(await res.json());
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [id]);
+
+  const withdraw = async () => {
+    if (!confirm("Withdraw this application?")) return;
+    const res = await authFetch(`${BACKEND_URL}/api/team-registrations/${id}`, { method: "DELETE" });
+    if (res.ok || res.status === 204) navigate("/teams/registrations");
+  };
+
+  if (loading) return <div className="team-reg-form">Loading…</div>;
+  if (error || !row) return <div className="team-reg-form form-error">{error || "Not found"}</div>;
+
+  const isOwner = isAuthenticated && user?.id === row.submittedByUserId;
+
+  return (
+    <div className="team-reg-form">
+      <Link to="/teams/registrations">← Back to registrations</Link>
+      <h1>{row.teamName}</h1>
+      <p className={`status-${row.status}`}>Status: {row.status}</p>
+      <p>
+        Captain: {row.captainDiscord} / {row.captainRoblox}
+      </p>
+      {row.viceDiscord && (
+        <p>
+          Vice: {row.viceDiscord} / {row.viceRoblox}
+        </p>
+      )}
+      {row.hexColor && (
+        <p>
+          Colors: <span style={{ color: row.hexColor }}>{row.hexColor}</span> / {row.brickColor}
+        </p>
+      )}
+      {row.priorLeagueExperience && <p>Experience: {row.priorLeagueExperience}</p>}
+      {row.roster && (
+        <>
+          <h2>Roster</h2>
+          <ul>
+            {row.roster.map((p, i) => (
+              <li key={i}>
+                {p.discord} — {p.roblox}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {isOwner && (row.status === "pending" || row.status === "conflict") && (
+        <button type="button" onClick={() => void withdraw()}>
+          Withdraw application
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default TeamRegistrationDetail;

--- a/FE/src/components/TeamRegistrationDetail.tsx
+++ b/FE/src/components/TeamRegistrationDetail.tsx
@@ -4,6 +4,7 @@ import { authFetch } from "../hooks/authFetch";
 import { BACKEND_URL } from "../constants/api";
 import { useAuth } from "../context/authContext";
 import type { TeamRegistration } from "../types/interfaces";
+import { RegStatusBadge } from "./RegStatusBadge";
 import "../styles/TeamRegistrations.css";
 
 const TeamRegistrationDetail: React.FC = () => {
@@ -34,47 +35,108 @@ const TeamRegistrationDetail: React.FC = () => {
     if (res.ok || res.status === 204) navigate("/teams/registrations");
   };
 
-  if (loading) return <div className="team-reg-form">Loading…</div>;
-  if (error || !row) return <div className="team-reg-form form-error">{error || "Not found"}</div>;
+  if (loading) {
+    return (
+      <div className="team-reg-form">
+        <div className="team-reg-card team-reg-gate">
+          <p className="team-regs-muted">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !row) {
+    return (
+      <div className="team-reg-form">
+        <div className="team-reg-card">
+          <Link className="team-reg-back" to="/teams/registrations">
+            ← Back to registrations
+          </Link>
+          <p className="form-error">{error || "Not found"}</p>
+        </div>
+      </div>
+    );
+  }
 
   const isOwner = isAuthenticated && user?.id === row.submittedByUserId;
 
   return (
     <div className="team-reg-form">
-      <Link to="/teams/registrations">← Back to registrations</Link>
-      <h1>{row.teamName}</h1>
-      <p className={`status-${row.status}`}>Status: {row.status}</p>
-      <p>
-        Captain: {row.captainDiscord} / {row.captainRoblox}
-      </p>
-      {row.viceDiscord && (
-        <p>
-          Vice: {row.viceDiscord} / {row.viceRoblox}
-        </p>
-      )}
-      {row.hexColor && (
-        <p>
-          Colors: <span style={{ color: row.hexColor }}>{row.hexColor}</span> / {row.brickColor}
-        </p>
-      )}
-      {row.priorLeagueExperience && <p>Experience: {row.priorLeagueExperience}</p>}
-      {row.roster && (
-        <>
-          <h2>Roster</h2>
-          <ul>
-            {row.roster.map((p, i) => (
-              <li key={i}>
-                {p.discord} — {p.roblox}
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
-      {isOwner && (row.status === "pending" || row.status === "conflict") && (
-        <button type="button" onClick={() => void withdraw()}>
-          Withdraw application
-        </button>
-      )}
+      <div className="team-regs-nav">
+        <Link to="/teams">League teams</Link>
+        <span aria-hidden="true">·</span>
+        <Link to="/teams/registrations">Team registrations</Link>
+        <span aria-hidden="true">·</span>
+        <span className="team-regs-nav-active">{row.teamName}</span>
+      </div>
+
+      <div className="team-reg-card">
+        <Link className="team-reg-back" to="/teams/registrations">
+          ← Back to registrations
+        </Link>
+
+        <div className="team-reg-detail-title-row">
+          <h1>{row.teamName}</h1>
+          <RegStatusBadge status={row.status} />
+        </div>
+
+        <dl className="team-regs-detail-stats" style={{ margin: "1.25rem 0" }}>
+          <div className="team-regs-detail-stat">
+            <dt>Captain</dt>
+            <dd>
+              {row.captainDiscord} / {row.captainRoblox}
+            </dd>
+          </div>
+          {(row.viceDiscord || row.viceRoblox) && (
+            <div className="team-regs-detail-stat">
+              <dt>Vice captain</dt>
+              <dd>
+                {row.viceDiscord} / {row.viceRoblox}
+              </dd>
+            </div>
+          )}
+          {row.hexColor && (
+            <div className="team-regs-detail-stat">
+              <dt>Colors</dt>
+              <dd>
+                <span className="team-regs-color-swatch" style={{ background: row.hexColor }} aria-hidden />
+                {row.hexColor}
+                {row.brickColor ? ` · ${row.brickColor}` : ""}
+              </dd>
+            </div>
+          )}
+          {row.priorLeagueExperience && (
+            <div className="team-regs-detail-stat team-regs-detail-stat--wide">
+              <dt>Prior experience</dt>
+              <dd>{row.priorLeagueExperience}</dd>
+            </div>
+          )}
+        </dl>
+
+        {row.roster && row.roster.length > 0 && (
+          <section className="team-reg-section">
+            <h2>Roster</h2>
+            <ul className="team-regs-roster">
+              {row.roster.map((p, i) => (
+                <li key={i}>
+                  <span className="team-regs-roster-label">P{i + 1}</span>
+                  <span>{p.discord}</span>
+                  <span className="team-regs-muted">·</span>
+                  <span>{p.roblox}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {isOwner && (row.status === "pending" || row.status === "conflict") && (
+          <div className="form-actions">
+            <button type="button" className="team-regs-cta team-regs-cta--danger" onClick={() => void withdraw()}>
+              Withdraw application
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/FE/src/components/TeamRegistrations.tsx
+++ b/FE/src/components/TeamRegistrations.tsx
@@ -4,7 +4,9 @@ import { useRegion } from "../context/regionContext";
 import { useAuth } from "../context/authContext";
 import { useTeamRegistrations, useRegistrationSummary } from "../hooks/useTeamRegistrations";
 import type { RegionCode, TeamRegistration } from "../types/interfaces";
+import { RegStatusBadge, REGISTRATION_STATUSES } from "./RegStatusBadge";
 import "../styles/TeamRegistrations.css";
+import "../styles/ListingPage.css";
 
 const REGIONS: { code: RegionCode; label: string }[] = [
   { code: "na", label: "NA" },
@@ -30,7 +32,7 @@ const TeamRegistrations: React.FC = () => {
 
   const spotsLine =
     summary?.spotsLeft != null
-      ? `${summary.spotsLeft} team spot${summary.spotsLeft === 1 ? "" : "s"} left…`
+      ? `${summary.spotsLeft} team spot${summary.spotsLeft === 1 ? "" : "s"} left`
       : null;
 
   return (
@@ -44,12 +46,30 @@ const TeamRegistrations: React.FC = () => {
       </div>
 
       <header className="team-regs-header">
-        <h1>Team registrations</h1>
-        <p>{header}</p>
-        {spotsLine && <p className="team-regs-spots">{spotsLine}</p>}
+        <div className="team-regs-header-body">
+          <h1>Team registrations</h1>
+          <p>
+            Public applications for the current registration window. Select a row for a quick
+            preview, or open full details.
+          </p>
+          <p className="team-regs-spots">{header}</p>
+          {spotsLine && <p className="team-regs-muted">{spotsLine}</p>}
+        </div>
+        <div className="team-regs-header-actions">
+          <Link className="team-regs-cta" to="/teams/register">
+            {isAuthenticated ? "Register a team" : "Log in to register"}
+          </Link>
+          <div className="team-regs-legend" aria-label="Status legend">
+            {REGISTRATION_STATUSES.map((status) => (
+              <div className="team-regs-legend-item" key={status}>
+                <RegStatusBadge status={status} />
+              </div>
+            ))}
+          </div>
+        </div>
       </header>
 
-      <div className="team-regs-region-tabs" role="tablist">
+      <div className="team-regs-region-tabs" role="tablist" aria-label="Region">
         {REGIONS.map((r) => (
           <button
             key={r.code}
@@ -68,7 +88,7 @@ const TeamRegistrations: React.FC = () => {
         ))}
       </div>
 
-      {loading && <p>Loading…</p>}
+      {loading && <p className="team-regs-muted">Loading registrations…</p>}
       {error && <p className="team-regs-error">{error}</p>}
 
       {!loading && !error && (
@@ -83,38 +103,72 @@ const TeamRegistrations: React.FC = () => {
               </tr>
             </thead>
             <tbody>
-              {data.map((row) => (
-                <tr
-                  key={row.id}
-                  className={`status-${row.status} ${selected?.id === row.id ? "selected" : ""}`}
-                  onClick={() => setSelected(selected?.id === row.id ? null : row)}
-                >
-                  <td>{row.teamName}</td>
-                  <td>{row.captainDiscord}</td>
-                  <td>{row.captainRoblox}</td>
-                  <td>{row.status}</td>
-                </tr>
-              ))}
+              {data.map((row) => {
+                const isSelected = selected?.id === row.id;
+                return (
+                  <React.Fragment key={row.id}>
+                    <tr
+                      className={`listing-row-clickable ${isSelected ? "selected listing-row-expanded" : ""}`}
+                      onClick={() => setSelected(isSelected ? null : row)}
+                    >
+                      <td className="team-name-cell">{row.teamName}</td>
+                      <td>{row.captainDiscord}</td>
+                      <td>{row.captainRoblox}</td>
+                      <td>
+                        <RegStatusBadge status={row.status} />
+                      </td>
+                    </tr>
+                    {isSelected && (
+                      <tr className="listing-table-detail-row">
+                        <td colSpan={4}>
+                          <div className="team-regs-detail">
+                            <dl className="team-regs-detail-stats">
+                              <div className="team-regs-detail-stat">
+                                <dt>Status</dt>
+                                <dd>
+                                  <RegStatusBadge status={row.status} />
+                                </dd>
+                              </div>
+                              <div className="team-regs-detail-stat">
+                                <dt>Captain</dt>
+                                <dd>
+                                  {row.captainDiscord} / {row.captainRoblox}
+                                </dd>
+                              </div>
+                              {row.hexColor && (
+                                <div className="team-regs-detail-stat">
+                                  <dt>Colors</dt>
+                                  <dd>
+                                    <span
+                                      className="team-regs-color-swatch"
+                                      style={{ background: row.hexColor }}
+                                      aria-hidden
+                                    />
+                                    {row.hexColor}
+                                    {row.brickColor ? ` · ${row.brickColor}` : ""}
+                                  </dd>
+                                </div>
+                              )}
+                            </dl>
+                            <Link className="team-regs-cta team-regs-cta--secondary" to={`/teams/registrations/${row.id}`}>
+                              View full details
+                            </Link>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                );
+              })}
               {data.length === 0 && (
                 <tr>
-                  <td colSpan={4}>No registrations yet for this region.</td>
+                  <td colSpan={4} className="listing-table-empty">
+                    No registrations yet for this region.
+                  </td>
                 </tr>
               )}
             </tbody>
           </table>
-        </div>
-      )}
-
-      {selected && (
-        <div className="team-regs-detail">
-          <h2>{selected.teamName}</h2>
-          <p>
-            Status: <strong>{selected.status}</strong>
-          </p>
-          <p>
-            Captain: {selected.captainDiscord} / {selected.captainRoblox}
-          </p>
-          <Link to={`/teams/registrations/${selected.id}`}>View full details</Link>
         </div>
       )}
     </div>

--- a/FE/src/components/TeamRegistrations.tsx
+++ b/FE/src/components/TeamRegistrations.tsx
@@ -1,0 +1,124 @@
+import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useRegion } from "../context/regionContext";
+import { useAuth } from "../context/authContext";
+import { useTeamRegistrations, useRegistrationSummary } from "../hooks/useTeamRegistrations";
+import type { RegionCode, TeamRegistration } from "../types/interfaces";
+import "../styles/TeamRegistrations.css";
+
+const REGIONS: { code: RegionCode; label: string }[] = [
+  { code: "na", label: "NA" },
+  { code: "eu", label: "EU" },
+  { code: "as", label: "AS" },
+];
+
+const TeamRegistrations: React.FC = () => {
+  const { regions, setActiveRegion, activeRegion } = useRegion();
+  const { isAuthenticated } = useAuth();
+  const activeCode = (activeRegion?.code || "na") as RegionCode;
+  const { data, loading, error } = useTeamRegistrations({ region: activeCode });
+  const summary = useRegistrationSummary(activeCode);
+  const [selected, setSelected] = useState<TeamRegistration | null>(null);
+
+  const header = useMemo(() => {
+    if (!summary) return "Accepted teams";
+    if (summary.capacity != null) {
+      return `Accepted teams ${summary.accepted}/${summary.capacity}`;
+    }
+    return `Accepted teams ${summary.accepted}`;
+  }, [summary]);
+
+  const spotsLine =
+    summary?.spotsLeft != null
+      ? `${summary.spotsLeft} team spot${summary.spotsLeft === 1 ? "" : "s"} left…`
+      : null;
+
+  return (
+    <div className="team-regs-page">
+      <div className="team-regs-nav">
+        <Link to="/teams">League teams</Link>
+        <span aria-hidden="true">·</span>
+        <span className="team-regs-nav-active">Team registrations</span>
+        <span aria-hidden="true">·</span>
+        <Link to="/teams/register">{isAuthenticated ? "Register a team" : "Log in to register"}</Link>
+      </div>
+
+      <header className="team-regs-header">
+        <h1>Team registrations</h1>
+        <p>{header}</p>
+        {spotsLine && <p className="team-regs-spots">{spotsLine}</p>}
+      </header>
+
+      <div className="team-regs-region-tabs" role="tablist">
+        {REGIONS.map((r) => (
+          <button
+            key={r.code}
+            type="button"
+            role="tab"
+            aria-selected={activeCode === r.code}
+            className={activeCode === r.code ? "active" : undefined}
+            onClick={() => {
+              setSelected(null);
+              const match = regions.find((x) => x.code === r.code);
+              if (match) setActiveRegion(match);
+            }}
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+
+      {loading && <p>Loading…</p>}
+      {error && <p className="team-regs-error">{error}</p>}
+
+      {!loading && !error && (
+        <div className="team-regs-table-wrap">
+          <table className="team-regs-table">
+            <thead>
+              <tr>
+                <th>Team</th>
+                <th>Captain Discord</th>
+                <th>Captain Roblox</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((row) => (
+                <tr
+                  key={row.id}
+                  className={`status-${row.status} ${selected?.id === row.id ? "selected" : ""}`}
+                  onClick={() => setSelected(selected?.id === row.id ? null : row)}
+                >
+                  <td>{row.teamName}</td>
+                  <td>{row.captainDiscord}</td>
+                  <td>{row.captainRoblox}</td>
+                  <td>{row.status}</td>
+                </tr>
+              ))}
+              {data.length === 0 && (
+                <tr>
+                  <td colSpan={4}>No registrations yet for this region.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {selected && (
+        <div className="team-regs-detail">
+          <h2>{selected.teamName}</h2>
+          <p>
+            Status: <strong>{selected.status}</strong>
+          </p>
+          <p>
+            Captain: {selected.captainDiscord} / {selected.captainRoblox}
+          </p>
+          <Link to={`/teams/registrations/${selected.id}`}>View full details</Link>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TeamRegistrations;

--- a/FE/src/components/TeamStaffEdit.tsx
+++ b/FE/src/components/TeamStaffEdit.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from "react";
+import { useAuth } from "../context/authContext";
+import { authFetch } from "../hooks/authFetch";
+import { BACKEND_URL } from "../constants/api";
+import type { Team, Player } from "../types/interfaces";
+
+const TeamStaffEdit: React.FC<{ team: Team; onUpdated?: (t: Team) => void }> = ({ team, onUpdated }) => {
+  const { user, isAuthenticated } = useAuth();
+  const [meta, setMeta] = useState<{ captainCanEdit?: boolean; staffRole?: string | null } | null>(null);
+  const [name, setName] = useState(team.name);
+  const [hexColor, setHexColor] = useState(team.hexColor || "#2D3C50");
+  const [brickColor, setBrickColor] = useState(team.brickColor || "");
+  const [logoUrl, setLogoUrl] = useState(team.logoUrl || "");
+  const [roster, setRoster] = useState(
+    (team.players || []).map((p: Player) => ({
+      discord: p.discordUsername || "",
+      roblox: p.robloxUsername || p.name,
+    }))
+  );
+  const [message, setMessage] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated || !user) return;
+    void (async () => {
+      const res = await authFetch(`${BACKEND_URL}/api/teams/${team.id}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      // compute can-edit client-side from ownership if API doesn't enrich
+      const isStaff =
+        data.captainUserId === user.id ||
+        data.viceCaptainUserId === user.id ||
+        data.courtCaptainUserId === user.id;
+      const seasonOk = data.season?.captainEditEnabled !== false;
+      const teamOk = data.captainEditEnabled !== false;
+      setMeta({
+        captainCanEdit: Boolean(isStaff && seasonOk && teamOk),
+        staffRole:
+          data.captainUserId === user.id
+            ? "captain"
+            : data.viceCaptainUserId === user.id
+              ? "vice_captain"
+              : data.courtCaptainUserId === user.id
+                ? "court_captain"
+                : null,
+      });
+    })();
+  }, [team.id, isAuthenticated, user]);
+
+  if (!meta?.captainCanEdit) {
+    if (user && (team.captainUserId === user.id || team.viceCaptainUserId === user.id || team.courtCaptainUserId === user.id)) {
+      return <p className="text-muted">Team editing is locked for this season or team.</p>;
+    }
+    return null;
+  }
+
+  const save = async () => {
+    setSaving(true);
+    setMessage(null);
+    try {
+      const body: Record<string, unknown> = {
+        hexColor: hexColor.startsWith("#") ? hexColor : `#${hexColor}`,
+        brickColor,
+        logoUrl: logoUrl || null,
+        roster,
+      };
+      if (meta.staffRole === "captain") body.name = name;
+
+      const res = await authFetch(`${BACKEND_URL}/api/teams/${team.id}/staff`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Save failed");
+      setMessage("Saved");
+      onUpdated?.(data);
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="team-staff-edit" style={{ marginTop: "1.5rem", paddingTop: "1rem", borderTop: "1px solid #ddd" }}>
+      <h3>Edit team ({meta.staffRole})</h3>
+      {meta.staffRole === "captain" && (
+        <label>
+          Name
+          <input value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+      )}
+      <label>
+        Hex
+        <input value={hexColor} onChange={(e) => setHexColor(e.target.value)} />
+      </label>
+      <label>
+        Brick
+        <input value={brickColor} onChange={(e) => setBrickColor(e.target.value)} />
+      </label>
+      <label>
+        Logo URL
+        <input value={logoUrl} onChange={(e) => setLogoUrl(e.target.value)} />
+      </label>
+      <h4>Roster</h4>
+      {roster.map((row, i) => (
+        <div key={i} className="roster-row">
+          <input
+            value={row.discord}
+            placeholder="Discord"
+            onChange={(e) =>
+              setRoster((r) => r.map((x, idx) => (idx === i ? { ...x, discord: e.target.value } : x)))
+            }
+          />
+          <input
+            value={row.roblox}
+            placeholder="Roblox"
+            onChange={(e) =>
+              setRoster((r) => r.map((x, idx) => (idx === i ? { ...x, roblox: e.target.value } : x)))
+            }
+          />
+        </div>
+      ))}
+      <button type="button" onClick={() => setRoster((r) => [...r, { discord: "", roblox: "" }])}>
+        Add player
+      </button>
+      <div className="form-actions">
+        <button type="button" disabled={saving} onClick={() => void save()}>
+          {saving ? "Saving…" : "Save changes"}
+        </button>
+      </div>
+      {message && <p>{message}</p>}
+    </section>
+  );
+};
+
+export default TeamStaffEdit;

--- a/FE/src/components/Teams.tsx
+++ b/FE/src/components/Teams.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from "react";
 /* Bring in the navigate helper from React Router */
 import { useNavigate }                          from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useMediumTeams, useSkinnySeasons }                             from "../hooks/allFetch";
 import "../styles/Teams.css";
 import "../styles/ListingPage.css";
+import "../styles/TeamRegistrations.css";
 import SearchBar                                from "./Searchbar";
 import Pagination                               from "./Pagination";
 import FilterBar                                from "./ui/FilterBar";
@@ -101,6 +103,13 @@ const Teams: React.FC = () =>
 
     return (
         <div className={`teams-page ${loading ? 'loading' : ''}`}>
+            <div className="team-regs-nav" style={{ padding: "0.75rem 1rem" }}>
+                <span className="team-regs-nav-active">League teams</span>
+                <span>·</span>
+                <Link to="/teams/registrations">Team registrations</Link>
+                <span>·</span>
+                <Link to="/teams/register">Register a team</Link>
+            </div>
             <div className="listing-controls-toolbar">
                     <FilterBar onReset={(searchQuery || seasonFilter || placementFilter) ? clearFilters : undefined}>
                         <div className="teams-season-filter">

--- a/FE/src/components/UserProfile.tsx
+++ b/FE/src/components/UserProfile.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 import { authFetch } from "../hooks/authFetch";
 import { useAuth } from "../context/authContext";
 import { BACKEND_URL } from "../constants/api";
+import { startRobloxOAuth } from "../hooks/useTeamRegistrations";
 import "../styles/UserProfile.css";
 
 interface Article {
@@ -17,10 +18,13 @@ interface Article {
 interface UserProfile {
     id:        number;
     username:  string;
-    email:     string;
+    email:     string | null;
     role:      string;
     createdAt: string;
     updatedAt: string;
+    robloxUsername?: string | null;
+    robloxUserId?: string | null;
+    hasPassword?: boolean;
     articles?: Article[];
 }
 
@@ -113,11 +117,42 @@ const ProfilePage: React.FC = () =>
 
             <div className="profile-card">
                 <p><strong>Username:</strong> {profile.username}</p>
-                <p><strong>Email:</strong>    {profile.email}</p>
+                <p><strong>Email:</strong>    {profile.email || "—"}</p>
                 <p>
                     <strong>Role / Permissions level:</strong>{" "}
                     {profile.role}
                 </p>
+                <p>
+                    <strong>Roblox:</strong>{" "}
+                    {profile.robloxUsername ? `@${profile.robloxUsername}` : "Not connected"}
+                </p>
+                <div className="profile-roblox-actions">
+                    {!profile.robloxUsername ? (
+                        <button type="button" onClick={() => void startRobloxOAuth("connect")}>
+                            Connect Roblox
+                        </button>
+                    ) : (
+                        <button
+                            type="button"
+                            onClick={async () => {
+                                const res = await authFetch(
+                                    `${BACKEND_URL}/api/auth/roblox/unlink`,
+                                    { method: "POST" },
+                                    token
+                                );
+                                if (res.ok) {
+                                    const data = await res.json();
+                                    setProfile((p) => (p ? { ...p, ...data } : p));
+                                } else {
+                                    const data = await res.json().catch(() => ({}));
+                                    alert(data.error || "Failed to unlink");
+                                }
+                            }}
+                        >
+                            Disconnect Roblox
+                        </button>
+                    )}
+                </div>
                 <p>
                     <strong>Join Date:</strong>{" "}
                     {new Date(profile.createdAt).toLocaleDateString()}

--- a/FE/src/components/portal/PortalLayout.tsx
+++ b/FE/src/components/portal/PortalLayout.tsx
@@ -22,6 +22,7 @@ const PortalLayout: React.FC = () => {
               <li><NavLink to="games">Games</NavLink></li>
               <li><NavLink to="stats">Stats</NavLink></li>
               <li><NavLink to="articles">Articles</NavLink></li>
+              <li><NavLink to="registrations">Registrations</NavLink></li>
               <li><NavLink to="applications">Applications</NavLink></li>
               <li><NavLink to="awards">Awards</NavLink></li>
             </ul>

--- a/FE/src/components/portal/RegistrationsHubPage.tsx
+++ b/FE/src/components/portal/RegistrationsHubPage.tsx
@@ -1,0 +1,220 @@
+import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTeamRegistrations, useRegistrationSummary } from "../../hooks/useTeamRegistrations";
+import { authFetch } from "../../hooks/authFetch";
+import { BACKEND_URL } from "../../constants/api";
+import type { RegionCode, TeamRegistration } from "../../types/interfaces";
+import "../../styles/TeamRegistrations.css";
+
+type Conflict = {
+  type: string;
+  teamName?: string;
+  roblox?: string;
+  existingTeamName?: string;
+  existingTeamId?: number;
+};
+
+const RegistrationsHubPage: React.FC = () => {
+  const [region, setRegion] = useState<RegionCode>("na");
+  const { data, loading, error, reload } = useTeamRegistrations({ region, full: true });
+  const summary = useRegistrationSummary(region);
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const [conflicts, setConflicts] = useState<Conflict[] | null>(null);
+  const [conflictId, setConflictId] = useState<number | null>(null);
+  const [rename, setRename] = useState("");
+  const [playerActions, setPlayerActions] = useState<Record<string, "transfer" | "exclude">>({});
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const header = useMemo(() => {
+    if (!summary) return "Accepted —";
+    if (summary.capacity != null) return `Accepted ${summary.accepted}/${summary.capacity}`;
+    return `Accepted ${summary.accepted}`;
+  }, [summary]);
+
+  const act = async (id: number, path: string, body?: unknown) => {
+    setMsg(null);
+    const res = await authFetch(`${BACKEND_URL}/api/team-registrations/${id}/${path}`, {
+      method: "POST",
+      headers: body ? { "Content-Type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.status === 409 && data.conflicts) {
+      setConflictId(id);
+      setConflicts(data.conflicts);
+      setRename(data.registration?.teamName || "");
+      return;
+    }
+    if (!res.ok) {
+      setMsg(data.error || "Action failed");
+      return;
+    }
+    setConflicts(null);
+    setConflictId(null);
+    setMsg("Updated");
+    await reload();
+  };
+
+  const resolve = async (decision?: "pending" | "denied") => {
+    if (!conflictId) return;
+    if (decision) {
+      await act(conflictId, "resolve", { decision });
+      return;
+    }
+    const players = Object.entries(playerActions).map(([roblox, action]) => ({ roblox, action }));
+    await act(conflictId, "resolve", { teamName: rename || undefined, players });
+  };
+
+  return (
+    <div className="team-regs-page">
+      <h1>Registrations</h1>
+      <p>
+        Manage team applications. Other registration types can be added here later.{" "}
+        <Link to="/portal/teams">League teams CRUD</Link>
+      </p>
+
+      <div className="team-regs-region-tabs">
+        {(["na", "eu", "as"] as RegionCode[]).map((r) => (
+          <button
+            key={r}
+            type="button"
+            className={region === r ? "active" : undefined}
+            onClick={() => {
+              setRegion(r);
+              setExpanded(null);
+            }}
+          >
+            {r.toUpperCase()}
+          </button>
+        ))}
+      </div>
+
+      <h2>Teams · {region.toUpperCase()}</h2>
+      <p>{header}</p>
+      {msg && <p>{msg}</p>}
+      {loading && <p>Loading…</p>}
+      {error && <p className="form-error">{error}</p>}
+
+      <div className="team-regs-table-wrap">
+        <table className="team-regs-table">
+          <thead>
+            <tr>
+              <th>Team</th>
+              <th>Submitter</th>
+              <th>Captain</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((row: TeamRegistration) => (
+              <React.Fragment key={row.id}>
+                <tr
+                  className={`status-${row.status}`}
+                  onClick={() => setExpanded(expanded === row.id ? null : row.id)}
+                >
+                  <td>{row.teamName}</td>
+                  <td>{row.submittedBy?.username || row.submittedByUserId}</td>
+                  <td>
+                    {row.captainDiscord} / {row.captainRoblox}
+                  </td>
+                  <td>{row.status}</td>
+                </tr>
+                {expanded === row.id && (
+                  <tr className={`status-${row.status}`}>
+                    <td colSpan={4}>
+                      <div className="team-regs-detail">
+                        <p>
+                          Hex {row.hexColor} · Brick {row.brickColor}
+                        </p>
+                        <p>
+                          Vice: {row.viceDiscord} / {row.viceRoblox}
+                        </p>
+                        <ul>
+                          {(row.roster || []).map((p, i) => (
+                            <li key={i}>
+                              {p.discord} — {p.roblox}
+                            </li>
+                          ))}
+                        </ul>
+                        <div className="form-actions">
+                          {(row.status === "pending" || row.status === "conflict") && (
+                            <>
+                              <button type="button" onClick={() => void act(row.id, "accept")}>
+                                Accept
+                              </button>
+                              <button type="button" onClick={() => void act(row.id, "deny")}>
+                                Deny
+                              </button>
+                            </>
+                          )}
+                          {row.status === "accepted" && (
+                            <button type="button" onClick={() => void act(row.id, "revoke")}>
+                              Revoke (while apps open)
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {conflicts && conflictId && (
+        <div className="ui-modal-backdrop" style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,.4)", display: "grid", placeItems: "center", zIndex: 50 }}>
+          <div className="ui-modal" style={{ background: "#fff", padding: "1.25rem", maxWidth: 520, width: "90%" }}>
+            <h3>Resolve conflicts</h3>
+            <label>
+              Team name
+              <input value={rename} onChange={(e) => setRename(e.target.value)} />
+            </label>
+            <ul>
+              {conflicts.map((c, i) => (
+                <li key={i}>
+                  {c.type === "name" && <>Name clash: {c.teamName}</>}
+                  {c.type === "player" && (
+                    <>
+                      Player {c.roblox} on {c.existingTeamName}{" "}
+                      <select
+                        value={playerActions[c.roblox!] || ""}
+                        onChange={(e) =>
+                          setPlayerActions((prev) => ({
+                            ...prev,
+                            [c.roblox!]: e.target.value as "transfer" | "exclude",
+                          }))
+                        }
+                      >
+                        <option value="">Choose…</option>
+                        <option value="transfer">Transfer</option>
+                        <option value="exclude">Exclude</option>
+                      </select>
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
+            <div className="form-actions">
+              <button type="button" onClick={() => void resolve()}>
+                Apply &amp; accept
+              </button>
+              <button type="button" onClick={() => void resolve("pending")}>
+                Revert pending
+              </button>
+              <button type="button" onClick={() => void resolve("denied")}>
+                Deny
+              </button>
+              <button type="button" onClick={() => { setConflicts(null); setConflictId(null); }}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RegistrationsHubPage;

--- a/FE/src/components/portal/RegistrationsHubPage.tsx
+++ b/FE/src/components/portal/RegistrationsHubPage.tsx
@@ -4,6 +4,8 @@ import { useTeamRegistrations, useRegistrationSummary } from "../../hooks/useTea
 import { authFetch } from "../../hooks/authFetch";
 import { BACKEND_URL } from "../../constants/api";
 import type { RegionCode, TeamRegistration } from "../../types/interfaces";
+import { RegStatusBadge } from "../RegStatusBadge";
+import Modal from "../ui/Modal";
 import "../../styles/TeamRegistrations.css";
 
 type Conflict = {
@@ -65,13 +67,25 @@ const RegistrationsHubPage: React.FC = () => {
     await act(conflictId, "resolve", { teamName: rename || undefined, players });
   };
 
+  const closeConflicts = () => {
+    setConflicts(null);
+    setConflictId(null);
+  };
+
   return (
     <div className="team-regs-page">
-      <h1>Registrations</h1>
-      <p>
-        Manage team applications. Other registration types can be added here later.{" "}
-        <Link to="/portal/teams">League teams CRUD</Link>
-      </p>
+      <header className="team-regs-header">
+        <div className="team-regs-header-body">
+          <h1>Registrations</h1>
+          <p>
+            Manage team applications. Other registration types can be added here later.{" "}
+            <Link to="/portal/teams">League teams CRUD</Link>
+          </p>
+          <p className="team-regs-spots">
+            Teams · {region.toUpperCase()} · {header}
+          </p>
+        </div>
+      </header>
 
       <div className="team-regs-region-tabs">
         {(["na", "eu", "as"] as RegionCode[]).map((r) => (
@@ -89,10 +103,8 @@ const RegistrationsHubPage: React.FC = () => {
         ))}
       </div>
 
-      <h2>Teams · {region.toUpperCase()}</h2>
-      <p>{header}</p>
-      {msg && <p>{msg}</p>}
-      {loading && <p>Loading…</p>}
+      {msg && <p className={msg === "Updated" ? "form-success" : "form-error"}>{msg}</p>}
+      {loading && <p className="team-regs-muted">Loading…</p>}
       {error && <p className="form-error">{error}</p>}
 
       <div className="team-regs-table-wrap">
@@ -106,113 +118,173 @@ const RegistrationsHubPage: React.FC = () => {
             </tr>
           </thead>
           <tbody>
-            {data.map((row: TeamRegistration) => (
-              <React.Fragment key={row.id}>
-                <tr
-                  className={`status-${row.status}`}
-                  onClick={() => setExpanded(expanded === row.id ? null : row.id)}
-                >
-                  <td>{row.teamName}</td>
-                  <td>{row.submittedBy?.username || row.submittedByUserId}</td>
-                  <td>
-                    {row.captainDiscord} / {row.captainRoblox}
-                  </td>
-                  <td>{row.status}</td>
-                </tr>
-                {expanded === row.id && (
-                  <tr className={`status-${row.status}`}>
-                    <td colSpan={4}>
-                      <div className="team-regs-detail">
-                        <p>
-                          Hex {row.hexColor} · Brick {row.brickColor}
-                        </p>
-                        <p>
-                          Vice: {row.viceDiscord} / {row.viceRoblox}
-                        </p>
-                        <ul>
-                          {(row.roster || []).map((p, i) => (
-                            <li key={i}>
-                              {p.discord} — {p.roblox}
-                            </li>
-                          ))}
-                        </ul>
-                        <div className="form-actions">
-                          {(row.status === "pending" || row.status === "conflict") && (
-                            <>
-                              <button type="button" onClick={() => void act(row.id, "accept")}>
-                                Accept
-                              </button>
-                              <button type="button" onClick={() => void act(row.id, "deny")}>
-                                Deny
-                              </button>
-                            </>
-                          )}
-                          {row.status === "accepted" && (
-                            <button type="button" onClick={() => void act(row.id, "revoke")}>
-                              Revoke (while apps open)
-                            </button>
-                          )}
-                        </div>
-                      </div>
+            {data.map((row: TeamRegistration) => {
+              const isOpen = expanded === row.id;
+              return (
+                <React.Fragment key={row.id}>
+                  <tr
+                    className={`listing-row-clickable ${isOpen ? "selected listing-row-expanded" : ""}`}
+                    onClick={() => setExpanded(isOpen ? null : row.id)}
+                  >
+                    <td className="team-name-cell">{row.teamName}</td>
+                    <td>{row.submittedBy?.username || row.submittedByUserId}</td>
+                    <td>
+                      {row.captainDiscord} / {row.captainRoblox}
+                    </td>
+                    <td>
+                      <RegStatusBadge status={row.status} />
                     </td>
                   </tr>
-                )}
-              </React.Fragment>
-            ))}
+                  {isOpen && (
+                    <tr className="listing-table-detail-row">
+                      <td colSpan={4}>
+                        <div className="team-regs-detail">
+                          <dl className="team-regs-detail-stats">
+                            <div className="team-regs-detail-stat">
+                              <dt>Colors</dt>
+                              <dd>
+                                {row.hexColor && (
+                                  <span
+                                    className="team-regs-color-swatch"
+                                    style={{ background: row.hexColor }}
+                                    aria-hidden
+                                  />
+                                )}
+                                {row.hexColor} · {row.brickColor}
+                              </dd>
+                            </div>
+                            <div className="team-regs-detail-stat">
+                              <dt>Vice</dt>
+                              <dd>
+                                {row.viceDiscord} / {row.viceRoblox}
+                              </dd>
+                            </div>
+                          </dl>
+                          <ul className="team-regs-roster">
+                            {(row.roster || []).map((p, i) => (
+                              <li key={i}>
+                                <span className="team-regs-roster-label">P{i + 1}</span>
+                                <span>{p.discord}</span>
+                                <span className="team-regs-muted">·</span>
+                                <span>{p.roblox}</span>
+                              </li>
+                            ))}
+                          </ul>
+                          <div className="form-actions" style={{ justifyContent: "flex-start" }}>
+                            {(row.status === "pending" || row.status === "conflict") && (
+                              <>
+                                <button
+                                  type="button"
+                                  className="team-regs-cta"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    void act(row.id, "accept");
+                                  }}
+                                >
+                                  Accept
+                                </button>
+                                <button
+                                  type="button"
+                                  className="team-regs-cta team-regs-cta--danger"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    void act(row.id, "deny");
+                                  }}
+                                >
+                                  Deny
+                                </button>
+                              </>
+                            )}
+                            {row.status === "accepted" && (
+                              <button
+                                type="button"
+                                className="team-regs-cta team-regs-cta--secondary"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  void act(row.id, "revoke");
+                                }}
+                              >
+                                Revoke (while apps open)
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              );
+            })}
+            {data.length === 0 && !loading && (
+              <tr>
+                <td colSpan={4} className="listing-table-empty">
+                  No registrations for this region.
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
 
-      {conflicts && conflictId && (
-        <div className="ui-modal-backdrop" style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,.4)", display: "grid", placeItems: "center", zIndex: 50 }}>
-          <div className="ui-modal" style={{ background: "#fff", padding: "1.25rem", maxWidth: 520, width: "90%" }}>
-            <h3>Resolve conflicts</h3>
-            <label>
-              Team name
-              <input value={rename} onChange={(e) => setRename(e.target.value)} />
-            </label>
-            <ul>
-              {conflicts.map((c, i) => (
-                <li key={i}>
-                  {c.type === "name" && <>Name clash: {c.teamName}</>}
-                  {c.type === "player" && (
-                    <>
-                      Player {c.roblox} on {c.existingTeamName}{" "}
-                      <select
-                        value={playerActions[c.roblox!] || ""}
-                        onChange={(e) =>
-                          setPlayerActions((prev) => ({
-                            ...prev,
-                            [c.roblox!]: e.target.value as "transfer" | "exclude",
-                          }))
-                        }
-                      >
-                        <option value="">Choose…</option>
-                        <option value="transfer">Transfer</option>
-                        <option value="exclude">Exclude</option>
-                      </select>
-                    </>
-                  )}
-                </li>
-              ))}
-            </ul>
-            <div className="form-actions">
-              <button type="button" onClick={() => void resolve()}>
-                Apply &amp; accept
-              </button>
-              <button type="button" onClick={() => void resolve("pending")}>
-                Revert pending
-              </button>
-              <button type="button" onClick={() => void resolve("denied")}>
-                Deny
-              </button>
-              <button type="button" onClick={() => { setConflicts(null); setConflictId(null); }}>
-                Close
-              </button>
-            </div>
+      <Modal
+        isOpen={Boolean(conflicts && conflictId)}
+        onClose={closeConflicts}
+        title="Resolve conflicts"
+      >
+        <div className="team-regs-conflict-modal">
+          <label>
+            Team name
+            <input value={rename} onChange={(e) => setRename(e.target.value)} />
+          </label>
+          <ul className="team-regs-conflict-list">
+            {(conflicts || []).map((c, i) => (
+              <li key={i}>
+                {c.type === "name" && <>Name clash: {c.teamName}</>}
+                {c.type === "player" && (
+                  <>
+                    Player {c.roblox} on {c.existingTeamName}{" "}
+                    <select
+                      value={playerActions[c.roblox!] || ""}
+                      onChange={(e) =>
+                        setPlayerActions((prev) => ({
+                          ...prev,
+                          [c.roblox!]: e.target.value as "transfer" | "exclude",
+                        }))
+                      }
+                    >
+                      <option value="">Choose…</option>
+                      <option value="transfer">Transfer</option>
+                      <option value="exclude">Exclude</option>
+                    </select>
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+          <div className="form-actions">
+            <button type="button" className="team-regs-cta" onClick={() => void resolve()}>
+              Apply &amp; accept
+            </button>
+            <button
+              type="button"
+              className="team-regs-cta team-regs-cta--secondary"
+              onClick={() => void resolve("pending")}
+            >
+              Revert pending
+            </button>
+            <button
+              type="button"
+              className="team-regs-cta team-regs-cta--danger"
+              onClick={() => void resolve("denied")}
+            >
+              Deny
+            </button>
+            <button type="button" className="team-regs-cta team-regs-cta--secondary" onClick={closeConflicts}>
+              Close
+            </button>
           </div>
         </div>
-      )}
+      </Modal>
     </div>
   );
 };

--- a/FE/src/components/portal/SeasonsPage.tsx
+++ b/FE/src/components/portal/SeasonsPage.tsx
@@ -310,6 +310,75 @@ const SeasonsPage: React.FC = () =>
             ),
         },
         {
+            key: "registrationsOpen",
+            header: "Apps Open",
+            render: (row: Season) => (
+                <input
+                    type="checkbox"
+                    checked={Boolean(row.registrationsOpen)}
+                    onChange={async (e) => {
+                        try {
+                            const updated = await patchSeason(row.id, {
+                                registrationsOpen: e.target.checked,
+                            });
+                            setLocalSeasons((prev) =>
+                                prev.map((s) => (s.id === row.id ? { ...s, ...updated } : s))
+                            );
+                        } catch (err) {
+                            console.error(err);
+                        }
+                    }}
+                />
+            ),
+        },
+        {
+            key: "captainEditEnabled",
+            header: "Staff Edit",
+            render: (row: Season) => (
+                <input
+                    type="checkbox"
+                    checked={row.captainEditEnabled !== false}
+                    onChange={async (e) => {
+                        try {
+                            const updated = await patchSeason(row.id, {
+                                captainEditEnabled: e.target.checked,
+                            });
+                            setLocalSeasons((prev) =>
+                                prev.map((s) => (s.id === row.id ? { ...s, ...updated } : s))
+                            );
+                        } catch (err) {
+                            console.error(err);
+                        }
+                    }}
+                />
+            ),
+        },
+        {
+            key: "maxTeams",
+            header: "Max Teams",
+            render: (row: Season) => (
+                <input
+                    type="number"
+                    min={1}
+                    style={{ width: "4.5rem" }}
+                    defaultValue={row.maxTeams ?? undefined}
+                    placeholder="—"
+                    onBlur={async (e) => {
+                        const raw = e.target.value.trim();
+                        const maxTeams = raw === "" ? null : Number(raw);
+                        try {
+                            const updated = await patchSeason(row.id, { maxTeams });
+                            setLocalSeasons((prev) =>
+                                prev.map((s) => (s.id === row.id ? { ...s, ...updated } : s))
+                            );
+                        } catch (err) {
+                            console.error(err);
+                        }
+                    }}
+                />
+            ),
+        },
+        {
             key:    "image",
             header: "Image URL",
             render: (row: Season) => (

--- a/FE/src/components/portal/TeamsPage.tsx
+++ b/FE/src/components/portal/TeamsPage.tsx
@@ -19,6 +19,8 @@ import RegionSeasonFields from "../ui/RegionSeasonFields";
 import { useFormRegionSeason } from "../../hooks/useFormRegionSeason";
 import { TEAM_PLACEMENT_OPTIONS } from "../../constants/teamPlacements";
 import { useDebouncedValue } from "../../hooks/useDebouncedValue";
+import { authFetch } from "../../hooks/authFetch";
+import { BACKEND_URL } from "../../constants/api";
 
 type EditField =
   | "name"
@@ -327,6 +329,32 @@ const TeamsPage: React.FC = () => {
             t.logoUrl || "N/A"
           )}
         </div>
+      ),
+    },
+    {
+      key: "captainEditEnabled",
+      header: "Staff Edit",
+      render: (t) => (
+        <input
+          type="checkbox"
+          checked={t.captainEditEnabled !== false}
+          onChange={async (e) => {
+            try {
+              const res = await authFetch(`${BACKEND_URL}/api/teams/${t.id}/flags`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ captainEditEnabled: e.target.checked }),
+              });
+              if (!res.ok) throw new Error("Failed");
+              const updated = await res.json();
+              setLocalTeams((prev) =>
+                prev.map((x) => (x.id === t.id ? { ...x, ...updated } : x))
+              );
+            } catch (err) {
+              console.error(err);
+            }
+          }}
+        />
       ),
     },
     {

--- a/FE/src/hooks/useTeamRegistrations.ts
+++ b/FE/src/hooks/useTeamRegistrations.ts
@@ -1,0 +1,67 @@
+import { authFetch } from "./authFetch";
+import { BACKEND_URL } from "../constants/api";
+import type { TeamRegistration, RegionCode } from "../types/interfaces";
+import { useEffect, useState, useCallback } from "react";
+
+export function useTeamRegistrations(params: {
+  region?: RegionCode;
+  seasonId?: number;
+  full?: boolean;
+}) {
+  const [data, setData] = useState<TeamRegistration[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const q = new URLSearchParams();
+      if (params.region) q.set("region", params.region);
+      if (params.seasonId) q.set("seasonId", String(params.seasonId));
+      if (params.full) q.set("full", "1");
+      const res = await authFetch(`${BACKEND_URL}/api/team-registrations?${q.toString()}`);
+      if (!res.ok) throw new Error("Failed to load registrations");
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [params.region, params.seasonId, params.full]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return { data, loading, error, reload };
+}
+
+export function useRegistrationSummary(region?: RegionCode) {
+  const [summary, setSummary] = useState<{
+    accepted: number;
+    spotsLeft: number | null;
+    capacity: number | null;
+    seasonId: number | null;
+    startDate?: string;
+    registrationsOpen?: boolean;
+    seasonNumber?: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const q = region ? `?region=${region}` : "";
+    void fetch(`${BACKEND_URL}/api/team-registrations/summary${q}`)
+      .then((r) => r.json())
+      .then(setSummary)
+      .catch(() => setSummary(null));
+  }, [region]);
+
+  return summary;
+}
+
+export async function startRobloxOAuth(intent: "connect" | "signup" | "login") {
+  const res = await authFetch(`${BACKEND_URL}/api/auth/roblox/start?intent=${intent}`);
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || "Failed to start Roblox OAuth");
+  window.location.href = data.url;
+}

--- a/FE/src/styles/Login.css
+++ b/FE/src/styles/Login.css
@@ -138,3 +138,24 @@ body {
     margin-bottom: 1rem;         /* same spacing */
     font-size: 0.9rem;           /* same font size */
 }
+
+.auth-sso-btn {
+  display: block;
+  width: 100%;
+  margin-top: 0.75rem;
+  padding: 0.65rem 1rem;
+  background: #fff;
+  border: 1px solid #2d3c50;
+  color: #2d3c50;
+  cursor: pointer;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.auth-sso-btn:hover {
+  background: #f3f6f9;
+}
+
+.profile-roblox-actions {
+  margin: 0.5rem 0 1rem;
+}

--- a/FE/src/styles/TeamRegistrations.css
+++ b/FE/src/styles/TeamRegistrations.css
@@ -1,152 +1,637 @@
-.team-regs-page {
-  max-width: 960px;
+/* Team registrations — public list, register form, detail, portal hub.
+   Uses tokens.css + ListingPage / CreateArticle patterns. */
+
+.team-regs-page,
+.team-reg-form {
+  width: 100%;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 1.5rem 1rem 3rem;
+  padding: 1.25rem 1.5rem 3rem;
+  box-sizing: border-box;
 }
 
 .team-regs-nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 1.25rem;
-  font-size: 0.95rem;
+  align-items: center;
+  gap: 0.5rem 0.65rem;
+  margin-bottom: 1.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
 }
 
 .team-regs-nav a {
-  color: var(--color-accent, #4a90c8);
+  color: var(--color-brand-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.team-regs-nav a:hover {
+  color: var(--color-brand-primary-hover);
+  text-decoration: underline;
 }
 
 .team-regs-nav-active {
-  font-weight: 600;
+  font-weight: 700;
+  color: var(--color-brand-primary);
 }
 
-.team-regs-header h1 {
-  margin: 0 0 0.35rem;
+.team-regs-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.team-regs-header-body h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-brand-primary);
+}
+
+.team-regs-header-body p {
+  margin: 0;
+  max-width: 42rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
 }
 
 .team-regs-spots {
-  color: var(--color-text-muted, #5a6a7a);
+  margin-top: 0.5rem;
+  font-weight: 600;
+  color: var(--color-brand-primary);
+}
+
+.team-regs-header-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.team-regs-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.25rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-brand-primary);
+  color: var(--color-text-on-brand);
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.team-regs-cta:hover {
+  background: var(--color-brand-primary-hover);
+  color: var(--color-text-on-brand);
+  text-decoration: none;
+}
+
+.team-regs-cta:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.team-regs-cta--secondary {
+  background: var(--color-bg);
+  color: var(--color-brand-primary);
+  border: 1px solid var(--color-brand-primary);
+}
+
+.team-regs-cta--secondary:hover {
+  background: var(--color-accent-hover-bg);
+  color: var(--color-brand-primary);
+}
+
+.team-regs-cta--danger {
+  background: var(--color-error);
+}
+
+.team-regs-cta--danger:hover {
+  background: #b91c1c;
+}
+
+/* Status legend + badges */
+.team-regs-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 1rem;
+  align-items: center;
+}
+
+.team-regs-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.reg-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.reg-status-badge.pending {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.reg-status-badge.conflict {
+  background: #ffe8cc;
+  color: #9a5b00;
+}
+
+.reg-status-badge.accepted {
+  background: #d4edda;
+  color: #155724;
+}
+
+.reg-status-badge.denied {
+  background: #f8d7da;
+  color: #721c24;
 }
 
 .team-regs-region-tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
-  margin: 1.25rem 0;
+  margin: 0 0 1.25rem;
 }
 
 .team-regs-region-tabs button {
-  border: 1px solid #c5d0dc;
-  background: #fff;
-  padding: 0.45rem 0.9rem;
+  border: 1px solid var(--color-brand-primary);
+  background: var(--color-brand-primary);
+  color: var(--color-text-on-brand);
+  padding: 0.5rem 1rem;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: background-color 0.2s ease, opacity 0.2s ease;
+  opacity: 0.55;
+}
+
+.team-regs-region-tabs button:hover {
+  background: var(--color-brand-primary-hover);
+  border-color: var(--color-brand-primary-hover);
+  opacity: 0.85;
 }
 
 .team-regs-region-tabs button.active {
-  background: #2d3c50;
-  color: #fff;
-  border-color: #2d3c50;
+  opacity: 1;
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
 }
 
+.team-regs-error,
+.form-error {
+  background: var(--color-error-bg);
+  color: #721c24;
+  border: 1px solid var(--color-error-border);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  margin-bottom: 1rem;
+}
+
+.form-success {
+  background: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  margin-bottom: 1rem;
+}
+
+.team-regs-muted {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+/* List table — ListingPage pattern */
 .team-regs-table-wrap {
+  width: 100%;
   overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
 }
 
 .team-regs-table {
   width: 100%;
   border-collapse: collapse;
+  font-size: 0.9375rem;
 }
 
-.team-regs-table th,
-.team-regs-table td {
+.team-regs-table thead th {
+  background: var(--color-bg-muted);
+  color: var(--color-brand-primary);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.75rem;
+  padding: 0.75rem 1.1rem;
   text-align: left;
-  padding: 0.75rem 0.85rem;
-  border-bottom: 1px solid #e2e8f0;
+  white-space: nowrap;
+  border-bottom: 2px solid var(--color-brand-primary);
 }
 
 .team-regs-table tbody tr {
+  border-bottom: 1px solid var(--color-border);
+  transition: background-color 0.15s ease;
+  background: var(--color-bg);
+}
+
+.team-regs-table tbody tr.listing-row-clickable {
   cursor: pointer;
-  background: #fff;
 }
 
-.team-regs-table tbody tr.status-accepted {
-  background: #d8f3dc;
+.team-regs-table tbody tr.listing-row-clickable:hover {
+  background: var(--color-row-hover);
 }
 
-.team-regs-table tbody tr.status-denied {
-  background: #f8d7da;
+.team-regs-table tbody tr.selected,
+.team-regs-table tbody tr.listing-row-expanded {
+  background: var(--color-accent-border);
 }
 
-.team-regs-table tbody tr.status-pending,
-.team-regs-table tbody tr.status-conflict {
-  background: #fff;
+.team-regs-table td {
+  padding: 0.85rem 1.1rem;
+  color: var(--color-text);
+  vertical-align: middle;
 }
 
-.team-regs-table tbody tr.selected {
-  outline: 2px solid #2d3c50;
+.team-regs-table .team-name-cell {
+  font-weight: 600;
+  color: var(--color-brand-primary);
+}
+
+.team-regs-color-swatch {
+  display: inline-block;
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  vertical-align: middle;
+  margin-right: 0.4rem;
 }
 
 .team-regs-detail {
-  margin-top: 1.5rem;
-  padding: 1rem;
-  border-top: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 0.25rem 0 0.5rem;
 }
 
-.team-regs-error {
-  color: #b00020;
+.team-regs-detail-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  gap: 0.75rem 1.25rem;
+  margin: 0;
 }
 
-.team-reg-form {
-  max-width: 720px;
-  margin: 0 auto;
-  padding: 1.5rem 1rem 3rem;
+.team-regs-detail-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
 }
 
-.team-reg-form fieldset {
-  border: 1px solid #d0d7de;
-  margin: 0 0 1.25rem;
-  padding: 1rem;
+.team-regs-detail-stat dt {
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
 }
 
-.team-reg-form legend {
-  font-weight: 600;
-  padding: 0 0.35rem;
+.team-regs-detail-stat--wide {
+  grid-column: 1 / -1;
 }
 
-.team-reg-form label {
+
+.team-regs-roster {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.team-regs-roster li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  padding: 0.55rem 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.9rem;
+}
+
+.team-regs-roster-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  min-width: 4.5rem;
+}
+
+/* Register / detail form card */
+.team-reg-card {
+  background: var(--color-bg);
+  padding: 2rem 2.25rem;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--color-border);
+}
+
+.team-reg-card h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--color-brand-primary);
+}
+
+.team-reg-card > .team-regs-muted {
+  margin: 0 0 1.5rem;
+}
+
+.team-reg-section {
+  margin: 0 0 1.75rem;
+  padding: 0 0 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.team-reg-section:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.team-reg-section h2 {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-brand-primary);
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid var(--color-accent);
+}
+
+.team-reg-form .form-group {
+  margin-bottom: 1.15rem;
+}
+
+.team-reg-form .form-group label,
+.team-reg-form .form-check {
   display: block;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.45rem;
+  font-weight: 500;
+  color: var(--color-text);
+  font-size: 0.95rem;
 }
 
-.team-reg-form input[type="text"],
-.team-reg-form input[type="url"],
-.team-reg-form textarea,
-.team-reg-form select {
-  display: block;
+.team-reg-form .form-group input,
+.team-reg-form .form-group textarea,
+.team-reg-form .form-group select {
   width: 100%;
-  margin-top: 0.25rem;
-  padding: 0.45rem 0.55rem;
+  box-sizing: border-box;
+  margin-top: 0.4rem;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid #ddd;
+  border-radius: var(--radius-sm);
+  font-size: 1rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.team-reg-form .form-group input:focus,
+.team-reg-form .form-group textarea:focus,
+.team-reg-form .form-group select:focus {
+  outline: none;
+  border-color: var(--color-brand-primary);
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
+}
+
+.team-reg-form .form-group textarea {
+  resize: vertical;
+  min-height: 5rem;
+}
+
+.team-reg-form .form-check {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  margin-bottom: 0.9rem;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.team-reg-form .form-check input {
+  margin-top: 0.2rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  flex-shrink: 0;
+  accent-color: var(--color-brand-primary);
+}
+
+.team-reg-color-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.65rem;
+  align-items: center;
+  margin-top: 0.4rem;
+}
+
+.team-reg-color-row input[type="color"] {
+  width: 2.75rem;
+  height: 2.5rem;
+  padding: 0.15rem;
+  border: 1px solid #ddd;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  background: var(--color-bg);
+}
+
+.team-reg-color-row input[type="text"] {
+  margin-top: 0;
 }
 
 .roster-row {
   display: grid;
   grid-template-columns: 1fr 1fr auto;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: 0.65rem;
+  margin-bottom: 0.65rem;
+  align-items: center;
+}
+
+.roster-row input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+}
+
+.roster-row input:focus {
+  outline: none;
+  border-color: var(--color-brand-primary);
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
+}
+
+.roster-row-remove {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.roster-row-remove:hover {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+  border-color: var(--color-error-border);
 }
 
 .form-actions {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
+  justify-content: flex-end;
+  margin-top: 1.5rem;
 }
 
-.form-error {
-  color: #b00020;
+.team-reg-gate {
+  text-align: center;
+  padding: 2.5rem 2rem;
+}
+
+.team-reg-gate p {
+  margin: 0 0 1.25rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.team-reg-gate-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.team-reg-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+  color: var(--color-brand-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.team-reg-back:hover {
+  text-decoration: underline;
+}
+
+.team-reg-detail-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.team-reg-detail-title-row h1 {
+  margin: 0;
+}
+
+.team-regs-portal-msg {
   margin-bottom: 1rem;
 }
 
-.form-success {
-  color: #1b7a3d;
-  margin-bottom: 1rem;
+.team-regs-conflict-modal label {
+  display: block;
+  margin: 0.75rem 0;
+  font-weight: 500;
+}
+
+.team-regs-conflict-modal input,
+.team-regs-conflict-modal select {
+  display: block;
+  width: 100%;
+  margin-top: 0.35rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
+}
+
+.team-regs-conflict-list {
+  list-style: none;
+  margin: 1rem 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.team-regs-conflict-list li {
+  padding: 0.75rem;
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+}
+
+@media (max-width: 768px) {
+  .team-regs-page,
+  .team-reg-form {
+    padding: 1rem 1rem 2.5rem;
+  }
+
+  .team-reg-card {
+    padding: 1.35rem 1.15rem;
+  }
+
+  .team-regs-header {
+    flex-direction: column;
+  }
+
+  .team-regs-header-actions {
+    align-items: stretch;
+    width: 100%;
+  }
+
+  .roster-row {
+    grid-template-columns: 1fr;
+  }
+
+  .team-regs-table thead th,
+  .team-regs-table td {
+    padding: 0.625rem 0.75rem;
+    font-size: 0.875rem;
+  }
 }

--- a/FE/src/styles/TeamRegistrations.css
+++ b/FE/src/styles/TeamRegistrations.css
@@ -1,0 +1,152 @@
+.team-regs-page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+}
+
+.team-regs-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.team-regs-nav a {
+  color: var(--color-accent, #4a90c8);
+}
+
+.team-regs-nav-active {
+  font-weight: 600;
+}
+
+.team-regs-header h1 {
+  margin: 0 0 0.35rem;
+}
+
+.team-regs-spots {
+  color: var(--color-text-muted, #5a6a7a);
+}
+
+.team-regs-region-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin: 1.25rem 0;
+}
+
+.team-regs-region-tabs button {
+  border: 1px solid #c5d0dc;
+  background: #fff;
+  padding: 0.45rem 0.9rem;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.team-regs-region-tabs button.active {
+  background: #2d3c50;
+  color: #fff;
+  border-color: #2d3c50;
+}
+
+.team-regs-table-wrap {
+  overflow-x: auto;
+}
+
+.team-regs-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.team-regs-table th,
+.team-regs-table td {
+  text-align: left;
+  padding: 0.75rem 0.85rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.team-regs-table tbody tr {
+  cursor: pointer;
+  background: #fff;
+}
+
+.team-regs-table tbody tr.status-accepted {
+  background: #d8f3dc;
+}
+
+.team-regs-table tbody tr.status-denied {
+  background: #f8d7da;
+}
+
+.team-regs-table tbody tr.status-pending,
+.team-regs-table tbody tr.status-conflict {
+  background: #fff;
+}
+
+.team-regs-table tbody tr.selected {
+  outline: 2px solid #2d3c50;
+}
+
+.team-regs-detail {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.team-regs-error {
+  color: #b00020;
+}
+
+.team-reg-form {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+}
+
+.team-reg-form fieldset {
+  border: 1px solid #d0d7de;
+  margin: 0 0 1.25rem;
+  padding: 1rem;
+}
+
+.team-reg-form legend {
+  font-weight: 600;
+  padding: 0 0.35rem;
+}
+
+.team-reg-form label {
+  display: block;
+  margin-bottom: 0.75rem;
+}
+
+.team-reg-form input[type="text"],
+.team-reg-form input[type="url"],
+.team-reg-form textarea,
+.team-reg-form select {
+  display: block;
+  width: 100%;
+  margin-top: 0.25rem;
+  padding: 0.45rem 0.55rem;
+}
+
+.roster-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.form-error {
+  color: #b00020;
+  margin-bottom: 1rem;
+}
+
+.form-success {
+  color: #1b7a3d;
+  margin-bottom: 1rem;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,16 @@ services:
       - ./BE/.env
     environment:
       - NODE_ENV=${NODE_ENV:-development}
+      # Local compose uses sync so a fresh volume works; production relies on migrations.
+      - TYPEORM_SYNCHRONIZE=true
       # ${DB_PASS:-password} is for local Docker Compose only — set DB_PASS explicitly in production
       - DATABASE_URL=postgresql://${DB_USER:-postgres}:${DB_PASS:-password}@db:5432/${DB_NAME:-volleyball}?sslmode=disable
       - REDIS_DISABLED=${REDIS_DISABLED:-true}
+      # Roblox SSO + redirects come from BE/.env (env_file). Do not blank them here with ${VAR:-}.
+      - FRONTEND_URL=http://localhost:5173
+      - BACKEND_PUBLIC_URL=http://localhost:3000
+      - ROBLOX_OAUTH_REDIRECT_URI=http://localhost:3000/api/auth/roblox/callback
+      - CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
     depends_on:
       db:
         condition: service_healthy
@@ -23,7 +30,7 @@ services:
       args:
         VITE_BACKEND_URL: ${VITE_BACKEND_URL:-http://localhost:3000}
     ports:
-      - "${DOCKER_FE_PORT:-5173}:80"
+      - "${DOCKER_FE_PORT:-5173}:8080"
     depends_on:
       - backend
 


### PR DESCRIPTION
## Summary
- Lands the remaining team application portal work (Roblox SSO, registration/staff APIs, public + admin UI) that is still not on `main` after the stacked branch merges
- Restyles team registration list/form/detail/portal hub to match existing listing tables, status badges, and form cards
- Fixes local Docker startup: FE maps `5173→8080`, strips nginx BOM, moves `run-migrations` out of the TypeORM migrations glob, enables compose `TYPEORM_SYNCHRONIZE` for fresh volumes
- Clarifies Roblox OAuth misconfig with a `503` + documents local redirect env vars; uses `ipKeyGenerator` for admin rate limiting

## Test plan
- [ ] `docker compose up --build -d` — FE `:5173`, BE `:3000/health`, DB `:5433`
- [ ] `/teams/registrations` shows styled table + status badges; expand row preview works
- [ ] `/teams/register` form matches app styling and submits when logged in
- [ ] Portal Registrations hub accept/deny/expand still works
- [ ] Without Roblox creds, `/api/auth/roblox/start` returns clear `503`; with `ROBLOX_OAUTH_*` set + localhost redirect registered, SSO start returns authorize URL

Made with [Cursor](https://cursor.com)